### PR TITLE
Add Python 3, in parallel than Python 2.7 support

### DIFF
--- a/examples/django_example/manage.py
+++ b/examples/django_example/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from django.core.management import execute_manager
 try:
-    import settings # Assumed to be in the same directory.
+    from . import settings # Assumed to be in the same directory.
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/examples/django_example/models.py
+++ b/examples/django_example/models.py
@@ -7,6 +7,6 @@ class Article(object):
         self.text = text
     
     def __unicode__(self):
-        s = u'<h1>%s</h1>' % self.title
-        s += u'<p>%s</p>' % self.text
+        s = '<h1>%s</h1>' % self.title
+        s += '<p>%s</p>' % self.text
         return s

--- a/examples/django_example/settings.py
+++ b/examples/django_example/settings.py
@@ -43,7 +43,7 @@ import inject
 
 
 def config_bindings(injector):
-    import bindings
+    from . import bindings
     bindings.config(injector)
 
 # Settings can be imported multiple times.

--- a/examples/django_example/views.py
+++ b/examples/django_example/views.py
@@ -1,8 +1,8 @@
 import inject
-from models import Article
+from .models import Article
 from django.http import HttpResponse
 
 
 @inject.param('article', Article)
 def index(request, article):
-    return HttpResponse(unicode(article))
+    return HttpResponse(str(article))

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -20,7 +20,7 @@ except ImportError:
 class Memcached(object):
     """Dummy memcached backend, always returns None."""
     def __init__(self, host, port):
-        print 'Connected memcached to %s:%s' % (host, port)
+        print('Connected memcached to %s:%s' % (host, port))
     
     def get(self, key):
         """Always return None."""
@@ -30,7 +30,7 @@ class Memcached(object):
 class Redis(object):
     """Redis backend, always returns a new User instance for any key."""
     def __init__(self, host, port):
-        print 'Connected redis to %s:%s' % (host, port)
+        print('Connected redis to %s:%s' % (host, port))
     
     def get(self, key):
         return User("Ivan Korobkov", "ivan.korobkov@gmail.com")
@@ -40,7 +40,7 @@ class MailService(object):
     """Sends emails."""
     def send(self, email, text):
         """send an email."""
-        print "Sent an email to %s, text=%s." % (email, text)
+        print("Sent an email to %s, text=%s." % (email, text))
 
 
 class User(object):
@@ -64,7 +64,7 @@ class User(object):
         if user:
             return user
         user = cls.redis.get(key)
-        print 'Loaded %s from redis.' % user
+        print('Loaded %s from redis.' % user)
         return user
     
     def __init__(self, name, email):

--- a/src/inject/exc.py
+++ b/src/inject/exc.py
@@ -47,7 +47,7 @@ class AutobindingFailed(Exception):
     '''Injector has failed to autobind a type.''' 
     
     def __init__(self, type, caused_by):
-        msg = u'Autobinding of %r failed because of %r' % (type, caused_by)
+        msg = 'Autobinding of %r failed because of %r' % (type, caused_by)
         return super(AutobindingFailed, self).__init__(msg)
 
 

--- a/src/inject/injections.py
+++ b/src/inject/injections.py
@@ -291,7 +291,7 @@ class ParamInjection(object):
     @classmethod
     def add_injection(cls, wrapper, name, injection):
         func = wrapper.func
-        func_code = func.func_code
+        func_code = func.__code__
         flags = func_code.co_flags
         
         if not flags & 0x04 and not flags & 0x08:

--- a/src/inject/injectors.py
+++ b/src/inject/injectors.py
@@ -45,6 +45,7 @@ from inject.exc import InjectorAlreadyRegistered, NoInjectorRegistered, \
     NotBoundError, AutobindingFailed
 from inject.log import configure_stdout_handler
 from inject.scopes import ApplicationScope, ThreadScope, RequestScope
+import collections
 
 
 logger = logging.getLogger('inject')
@@ -150,10 +151,10 @@ class Injector(object):
             if scope.is_bound(type) or scope.is_factory_bound(type):
                 return scope.get(type)
         
-        if self.autobind and callable(type):
+        if self.autobind and isinstance(type, collections.Callable):
             try:
                 inst = type()
-            except Exception, e:
+            except Exception as e:
                 raise AutobindingFailed(type, e)
             
             self.bind(type, inst)

--- a/src/inject/scopes.py
+++ b/src/inject/scopes.py
@@ -19,6 +19,7 @@ to create a new object every time a binding is accessed.
 import logging
 import threading
 from inject.exc import NoRequestError, FactoryNotCallable
+import collections
 
 
 class AbstractScope(object):
@@ -75,7 +76,7 @@ class AbstractScope(object):
         but only one factory for a type. However, the factory is instantiated
         for each thread/request.
         '''
-        if not callable(factory):
+        if not isinstance(factory, collections.Callable):
             raise FactoryNotCallable(factory)
         
         if self.is_factory_bound(type):

--- a/src/inject/utils.py
+++ b/src/inject/utils.py
@@ -42,7 +42,7 @@ def get_attrname_by_value(obj, attrvalue):
         
         return attrname
     
-    attrname = _get(obj.__dict__.iteritems())
+    attrname = _get(iter(obj.__dict__.items()))
     if attrname is not None:
         return attrname
     

--- a/src/inject_tests/middleware25_tests.py
+++ b/src/inject_tests/middleware25_tests.py
@@ -24,7 +24,7 @@ class WsgiTestCase(unittest.TestCase):
         def app(environ, start_response, scope):
             @inject.param('user', User)
             def greet_user(user):
-                return u'Hello, %s' % user.name
+                return 'Hello, %s' % user.name
             
             @inject.param('user', User)
             def foo(user):
@@ -44,9 +44,9 @@ class WsgiTestCase(unittest.TestCase):
         
         self.assertEqual(User.i, 3)
         
-        self.assertEqual(greet1, u'Hello, user1')
-        self.assertEqual(greet2, u'Hello, user2')
-        self.assertEqual(greet3, u'Hello, user3')
+        self.assertEqual(greet1, 'Hello, user1')
+        self.assertEqual(greet2, 'Hello, user2')
+        self.assertEqual(greet3, 'Hello, user3')
 
 
 class DjangoTestCase(unittest.TestCase):


### PR DESCRIPTION
Added Python 3 support in parallel to 2.7. Tests passes for both python 2 and 3 (apart from django one for python3, which is normal as there is no django python3 version). Used a single code base for it.

It should work as well with python 2.6, but I don't have the system to test it.

The simple example is running fine as well under both python version after conversion.
