### PR TITLE
	* Update to use getfullargspec when executing in python3.

### DIFF
--- a/src/inject.py
+++ b/src/inject.py
@@ -81,6 +81,7 @@ __url__ = 'https://github.com/ivan-korobkov/python-inject'
 import logging
 import threading
 import inspect
+import sys
 from functools import wraps
 
 logger = logging.getLogger('inject')
@@ -310,7 +311,10 @@ class _ParametersInjection(object):
         self._params = kwargs
 
     def __call__(self, func):
-        arg_names = inspect.getargspec(func).args
+        if sys.version_info.major == 2:
+            arg_names = inspect.getargspec(func).args
+        else:
+            arg_names = inspect.getfullargspec(func).args
         params = self._params
 
         @wraps(func)


### PR DESCRIPTION
I'm using inject inside python3.  It generally works well, but python3 deprecated getargspec.  It has been replaced by getfullargspec.

I find that in some of my unit tests, I'm having issues with functions that are keyword only.  This PR fixes the issue.  I've tested with both py2 and py3.
