### PR TITLE
Autoparams fix for return type annotation

### DIFF
--- a/src/inject.py
+++ b/src/inject.py
@@ -185,12 +185,18 @@ def autoparams(*selected_args):
     def autoparams_decorator(func):
         if sys.version_info[:2] < (3, 5):
             raise InjectorException('autoparams are supported from Python 3.5 onwards')
-        args_to_classes = dict(func.__annotations__)
+
+        full_args_spec = inspect.getfullargspec(func)
+        annotations_items = full_args_spec.annotations.items()
+        args_annotated_types = {
+            arg_name: annotated_type for arg_name, annotated_type in annotations_items
+            if arg_name in full_args_spec.args
+        }
         if selected_args:
-            keys_to_remove = set(args_to_classes.keys()) - set(selected_args)
+            keys_to_remove = set(args_annotated_types.keys()) - set(selected_args)
             for key in keys_to_remove:
-                del args_to_classes[key]
-        return _ParametersInjection(**args_to_classes)(func)
+                del args_annotated_types[key]
+        return _ParametersInjection(**args_annotated_types)(func)
 
     return autoparams_decorator
 

--- a/src/test_inject/test_autoparams.py
+++ b/src/test_inject/test_autoparams.py
@@ -148,3 +148,15 @@ class TestInjectAutoparams(BaseTestInject):
 
         self.assertRaises(TypeError, test_func)
         self.assertRaises(TypeError, test_func, a=1, c=3)
+
+    def test_autoparams_omits_return_type(self):
+        @inject.autoparams()
+        def test_func(a: str) -> int:
+            return a
+
+        def config(binder):
+            binder.bind(str, 'bazinga')
+
+        inject.configure(config)
+
+        assert test_func() == 'bazinga'


### PR DESCRIPTION
Use inspect module for getting type annotations instead of using `__annotations__`. This also fixes problem when previous implementation tried to inject keyword argument using annotation for return type