### PR TITLE
Make autoparams work with keyword-only parameters:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-import sys
 from distutils.core import setup
+import sys
 
 
 def read_description():
@@ -9,7 +9,7 @@ def read_description():
 
 setup(
     name='Inject',
-    version='3.5.0',
+    version='3.5.1dev0',
     url='https://github.com/ivankorobkov/python-inject',
     license='Apache License 2.0',
 

--- a/src/test_inject/test_autoparams.py
+++ b/src/test_inject/test_autoparams.py
@@ -16,7 +16,7 @@ class TestInjectAutoparams(BaseTestInject):
 
     def test_autoparams_multi(self):
         @inject.autoparams()
-        def test_func(a: 'A', b: 'B', c: 'C'):
+        def test_func(a: 'A', b: 'B', *, c: 'C'):
             return a, b, c
 
         def config(binder):
@@ -29,7 +29,7 @@ class TestInjectAutoparams(BaseTestInject):
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
-        assert test_func(10, 20, 30) == (10, 20, 30)
+        assert test_func(10, 20, c=30) == (10, 20, 30)
         assert test_func(a='a') == ('a', 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
@@ -39,7 +39,7 @@ class TestInjectAutoparams(BaseTestInject):
 
     def test_autoparams_with_defaults(self):
         @inject.autoparams()
-        def test_func(a=1, b: 'B' = None, c: 'C' = 300):
+        def test_func(a=1, b: 'B' = None, *, c: 'C' = 300):
             return a, b, c
 
         def config(binder):
@@ -51,7 +51,7 @@ class TestInjectAutoparams(BaseTestInject):
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
-        assert test_func(10, 20, 30) == (10, 20, 30)
+        assert test_func(10, 20, c=30) == (10, 20, 30)
         assert test_func(a='a') == ('a', 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
@@ -62,7 +62,7 @@ class TestInjectAutoparams(BaseTestInject):
     def test_autoparams_on_method(self):
         class Test:
             @inject.autoparams()
-            def func(self, a=1, b: 'B' = None, c: 'C' = None):
+            def func(self, a=1, b: 'B' = None, *, c: 'C' = None):
                 return self, a, b, c
 
         def config(binder):
@@ -75,7 +75,7 @@ class TestInjectAutoparams(BaseTestInject):
         assert test.func() == (test, 1, 2, 3)
         assert test.func(10) == (test, 10, 2, 3)
         assert test.func(10, 20) == (test, 10, 20, 3)
-        assert test.func(10, 20, 30) == (test, 10, 20, 30)
+        assert test.func(10, 20, c=30) == (test, 10, 20, 30)
         assert test.func(a='a') == (test, 'a', 2, 3)
         assert test.func(b='b') == (test, 1, 'b', 3)
         assert test.func(c='c') == (test, 1, 2, 'c')
@@ -88,7 +88,7 @@ class TestInjectAutoparams(BaseTestInject):
             # note inject must be *before* classmethod!
             @classmethod
             @inject.autoparams()
-            def func(cls, a=1, b: 'B' = None, c: 'C' = None):
+            def func(cls, a=1, b: 'B' = None, *, c: 'C' = None):
                 return cls, a, b, c
 
         def config(binder):
@@ -100,7 +100,7 @@ class TestInjectAutoparams(BaseTestInject):
         assert Test.func() == (Test, 1, 2, 3)
         assert Test.func(10) == (Test, 10, 2, 3)
         assert Test.func(10, 20) == (Test, 10, 20, 3)
-        assert Test.func(10, 20, 30) == (Test, 10, 20, 30)
+        assert Test.func(10, 20, c=30) == (Test, 10, 20, 30)
         assert Test.func(a='a') == (Test, 'a', 2, 3)
         assert Test.func(b='b') == (Test, 1, 'b', 3)
         assert Test.func(c='c') == (Test, 1, 2, 'c')
@@ -113,7 +113,7 @@ class TestInjectAutoparams(BaseTestInject):
             # note inject must be *before* classmethod!
             @classmethod
             @inject.autoparams()
-            def func(cls, a=1, b: 'B' = None, c: 'C' = None):
+            def func(cls, a=1, b: 'B' = None, *, c: 'C' = None):
                 return cls, a, b, c
 
         def config(binder):
@@ -126,7 +126,7 @@ class TestInjectAutoparams(BaseTestInject):
         assert test.func() == (Test, 1, 2, 3)
         assert test.func(10) == (Test, 10, 2, 3)
         assert test.func(10, 20) == (Test, 10, 20, 3)
-        assert test.func(10, 20, 30) == (Test, 10, 20, 30)
+        assert test.func(10, 20, c=30) == (Test, 10, 20, 30)
         assert test.func(a='a') == (Test, 'a', 2, 3)
         assert test.func(b='b') == (Test, 1, 'b', 3)
         assert test.func(c='c') == (Test, 1, 2, 'c')
@@ -136,7 +136,7 @@ class TestInjectAutoparams(BaseTestInject):
 
     def test_autoparams_only_selected(self):
         @inject.autoparams('a', 'c')
-        def test_func(a: 'A', b: 'B', c: 'C'):
+        def test_func(a: 'A', b: 'B', *, c: 'C'):
             return a, b, c
 
         def config(binder):


### PR DESCRIPTION
- v3.5.0 lost some compatibility with keyword-only parameters
- PEP8 fixes
- sync up versions and increment to a dev version