### PR TITLE
fix: export Binder in .pyi

### DIFF
--- a/src/inject.pyi
+++ b/src/inject.pyi
@@ -2,6 +2,7 @@ import typing
 
 
 T = typing.TypeVar('T')
+Binder = typing.TypeVar('Binder')
 Injector = typing.TypeVar('Injector')
 
 


### PR DESCRIPTION
we want to use type-hint in our project, but param `binder` can not be marked. Please export it in .pyi. 