### PR TITLE
Bug/typing issue with py37

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         )
     ],
 
-    install_requires=["typing; python_version<'3.5'"],
+    install_requires=['typing; python_version<"3.5"'],
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         )
     ],
 
-    install_requires=['typing'],
+    install_requires=["typing; python_version<'3.5'"],
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Removes typing as a requirement if the python version is above Py35. This is to address #34 