### PR TITLE
Remove include_package_data to install py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
 
     packages=['inject'],
     package_data={'inject': ['py.typed']},
-    include_package_data=True,
     zip_safe=False,
     
     classifiers=[


### PR DESCRIPTION
I found that sdist file does not include `py.typed`. For workaround, I found that when I remove `include_package_data` it works.