### PR TITLE
Use assertRaisesRegex instead of assertRaisesRegexp to fix deprecation warnings

### DIFF
--- a/test/test_binder.py
+++ b/test/test_binder.py
@@ -13,14 +13,14 @@ class TestBinder(TestCase):
     def test_bind__class_required(self):
         binder = Binder()
 
-        self.assertRaisesRegexp(InjectorException, 'Binding key cannot be None',
+        self.assertRaisesRegex(InjectorException, 'Binding key cannot be None',
                                 binder.bind, None, None)
 
     def test_bind__duplicate_binding(self):
         binder = Binder()
         binder.bind(int, 123)
 
-        self.assertRaisesRegexp(InjectorException, "Duplicate binding",
+        self.assertRaisesRegex(InjectorException, "Duplicate binding",
                                 binder.bind, int, 456)
 
     def test_bind_provider(self):
@@ -32,7 +32,7 @@ class TestBinder(TestCase):
 
     def test_bind_provider__provider_required(self):
         binder = Binder()
-        self.assertRaisesRegexp(InjectorException, "Provider cannot be None",
+        self.assertRaisesRegex(InjectorException, "Provider cannot be None",
                                 binder.bind_to_provider, int, None)
 
     def test_bind_constructor(self):
@@ -44,5 +44,5 @@ class TestBinder(TestCase):
 
     def test_bind_constructor__constructor_required(self):
         binder = Binder()
-        self.assertRaisesRegexp(InjectorException, "Constructor cannot be None",
+        self.assertRaisesRegex(InjectorException, "Constructor cannot be None",
                                 binder.bind_to_constructor, int, None)

--- a/test/test_inject_configuration.py
+++ b/test/test_inject_configuration.py
@@ -19,7 +19,7 @@ class TestInjectConfiguration(BaseTestInject):
     def test_configure__already_configured(self):
         inject.configure()
 
-        self.assertRaisesRegexp(InjectorException, 'Injector is already configured',
+        self.assertRaisesRegex(InjectorException, 'Injector is already configured',
                                 inject.configure)
 
     def test_configure_once__should_create_injector(self):
@@ -48,11 +48,11 @@ class TestInjectConfiguration(BaseTestInject):
         assert injector1 is not injector0
 
     def test_get_injector_or_die(self):
-        self.assertRaisesRegexp(InjectorException, 'No injector is configured',
+        self.assertRaisesRegex(InjectorException, 'No injector is configured',
                                 inject.get_injector_or_die)
 
     def test_configure__runtime_binding_disabled(self):
         injector = inject.configure(bind_in_runtime=False)
-        self.assertRaisesRegexp(InjectorException,
+        self.assertRaisesRegex(InjectorException,
                                 "No binding was found for key=<.* 'int'>",
                                 injector.get_instance, int)


### PR DESCRIPTION
Fixes below deprecation warnings regarding unittest assertion helper.

```
=========================================================================== warnings summary ===========================================================================
test/test_binder.py::TestBinder::test_bind__class_required
  /root/checked_repos/python-inject/test/test_binder.py:16: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException, 'Binding key cannot be None',

test/test_binder.py::TestBinder::test_bind__duplicate_binding
  /root/checked_repos/python-inject/test/test_binder.py:23: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException, "Duplicate binding",

test/test_binder.py::TestBinder::test_bind_constructor__constructor_required
  /root/checked_repos/python-inject/test/test_binder.py:47: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException, "Constructor cannot be None",

test/test_binder.py::TestBinder::test_bind_provider__provider_required
  /root/checked_repos/python-inject/test/test_binder.py:35: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException, "Provider cannot be None",

test/test_inject_configuration.py::TestInjectConfiguration::test_configure__already_configured
  /root/checked_repos/python-inject/test/test_inject_configuration.py:22: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException, 'Injector is already configured',

test/test_inject_configuration.py::TestInjectConfiguration::test_configure__runtime_binding_disabled
  /root/checked_repos/python-inject/test/test_inject_configuration.py:56: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException,

test/test_inject_configuration.py::TestInjectConfiguration::test_get_injector_or_die
  /root/checked_repos/python-inject/test/test_inject_configuration.py:51: DeprecationWarning: Please use assertRaisesRegex instead.
    self.assertRaisesRegexp(InjectorException, 'No injector is configured',

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================================== 46 passed, 7 warnings in 0.25s ====================================================================
```