### PR TITLE
Add attr_dc that works when using ClassVar annotation on class variable

### DIFF
--- a/inject/__init__.py
+++ b/inject/__init__.py
@@ -274,6 +274,16 @@ class _AttributeInjection(object):
         return instance(self._cls)
 
 
+class _AttributeInjectionDataclass(Generic[T]):
+    def __init__(self, cls: Binding) -> None:
+        self._cls = cls
+
+    def __get__(self, instance, owner) -> T:
+        if injector := get_injector():
+            return injector.get_instance(self._cls)
+        raise AttributeError
+
+
 class _ParameterInjection(Generic[T]):
     __slots__ = ('_name', '_cls')
 
@@ -410,6 +420,16 @@ def attr(cls: Hashable) -> Injectable: ...
 def attr(cls: Binding) -> Injectable:
     """Return a attribute injection (descriptor)."""
     return _AttributeInjection(cls)
+
+@overload
+def attr_dc(cls: Type[T]) -> T: ...
+
+@overload
+def attr_dc(cls: Hashable) -> Injectable: ...
+
+def attr_dc(cls: Binding) -> Injectable:
+    """Return a attribute injection (descriptor)."""
+    return _AttributeInjectionDataclass(cls)
 
 
 def param(name: str, cls: Optional[Binding] = None) -> Callable:

--- a/inject/__init__.py
+++ b/inject/__init__.py
@@ -279,7 +279,8 @@ class _AttributeInjectionDataclass(Generic[T]):
         self._cls = cls
 
     def __get__(self, instance, owner) -> T:
-        if injector := get_injector():
+        injector = get_injector()
+        if injector is not None:
             return injector.get_instance(self._cls)
         raise AttributeError
 

--- a/test/test_attr.py
+++ b/test/test_attr.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
 import inject
 from test import BaseTestInject
 
@@ -25,3 +28,45 @@ class TestInjectAttr(BaseTestInject):
 
         assert value0 == 123
         assert value1 == 123
+
+    def test_attr_on_dataclass_class_var_raises_error(self):
+        with self.assertRaises(inject.InjectorException):
+            @dataclass
+            class MyClass:
+                field: ClassVar[int] = inject.attr(int)
+
+
+class TestInjectAttrDataclass(BaseTestInject):
+    def test_attr_dc(self):
+        @dataclass
+        class MyClass(object):
+            field = inject.attr_dc(int)
+
+        inject.configure(lambda binder: binder.bind(int, 123))
+        my = MyClass()
+        value0 = my.field
+        value1 = my.field
+
+        assert value0 == 123
+        assert value1 == 123
+
+    def test_class_attr_dc(self):
+        class MyClass(object):
+            field = inject.attr_dc(int)
+
+        inject.configure(lambda binder: binder.bind(int, 123))
+        value0 = MyClass.field
+        value1 = MyClass.field
+
+        assert value0 == 123
+        assert value1 == 123
+
+    def test_attr_on_dataclass_class_var_works(self):
+        @dataclass
+        class MyClass:
+            field: ClassVar[int] = inject.attr_dc(int)
+
+        inject.configure(lambda binder: binder.bind(int, 123))
+
+        assert MyClass().field == 123
+        assert MyClass.field == 123


### PR DESCRIPTION
First I want to say that  I really like this library. Great work :) 

Using a ClassVar annotation on an attribute failed for dataclasses:
```python
from dataclasses import dataclass
from typing import ClassVar
import inject

@dataclass
class MyClass:
    field: ClassVar[int] = inject.attr(int)
```
raises: `inject.InjectorException: No injector is configured`

I was not sure whether to change the `_AttributeInjection` or give an argument to the `attr` function (something like is_dataclass).
Or if this is even desired since it works when you are not using the ClassVar annotation:
`field = inject.attr(int)`
