### PR TITLE
Add explicit param injection

### DIFF
--- a/inject/__init__.py
+++ b/inject/__init__.py
@@ -328,7 +328,6 @@ class _ParametersInjection(Generic[T]):
         if inspect.iscoroutinefunction(func):
             @wraps(func)
             async def async_injection_wrapper(*args: Any, **kwargs: Any) -> T:
-                print(args, kwargs)
                 arg_name_tuple = arg_names[:len(args)]
                 provided_params = frozenset(arg_name_tuple) | frozenset(kwargs.keys())
                 for param, cls in params_to_provide.items():
@@ -341,7 +340,6 @@ class _ParametersInjection(Generic[T]):
                         if args[idx] is ...:
                             args = args[:idx] + (instance(cls),) + args[idx + 1:]
                 async_func = cast(Callable[..., Awaitable[T]], func)
-                print(args, kwargs)
                 try:
                     return await async_func(*args, **kwargs)
                 except TypeError as previous_error:
@@ -353,7 +351,6 @@ class _ParametersInjection(Generic[T]):
         def injection_wrapper(*args: Any, **kwargs: Any) -> T:
             arg_name_tuple = arg_names[:len(args)]
             provided_params = frozenset(arg_name_tuple) | frozenset(kwargs.keys())
-            print(args, kwargs)
             for param, cls in params_to_provide.items():
                 if param not in provided_params:
                     kwargs[param] = instance(cls)
@@ -364,7 +361,6 @@ class _ParametersInjection(Generic[T]):
                     if args[idx] is ...:
                         args = args[:idx] + (instance(cls),) + args[idx + 1:]
             sync_func = cast(Callable[..., T], func)
-            print(args, kwargs)
             try:
                 return sync_func(*args, **kwargs)
             except TypeError as previous_error:

--- a/inject/__init__.py
+++ b/inject/__init__.py
@@ -104,6 +104,14 @@ _INJECTOR = None  # Shared injector instance.
 _INJECTOR_LOCK = threading.RLock()  # Guards injector initialization.
 _BINDING_LOCK = threading.RLock()  # Guards runtime bindings.
 
+MARKER = object()  # A marker object to explicitly set a parameter to be injected
+
+
+def set_marker(new_marker: Any):
+    global MARKER
+    MARKER = new_marker
+
+
 Injectable = Union[object, Any]
 T = TypeVar('T', bound=Injectable)
 Binding = Union[Type[Injectable], Hashable]
@@ -333,11 +341,11 @@ class _ParametersInjection(Generic[T]):
                 for param, cls in params_to_provide.items():
                     if param not in provided_params:
                         kwargs[param] = instance(cls)
-                    elif param in kwargs and kwargs[param] is ...:
+                    elif param in kwargs and kwargs[param] is MARKER:
                         kwargs[param] = instance(cls)
                     elif param in arg_name_tuple:
                         idx = arg_name_tuple.index(param)
-                        if args[idx] is ...:
+                        if args[idx] is MARKER:
                             args = args[:idx] + (instance(cls),) + args[idx + 1:]
                 async_func = cast(Callable[..., Awaitable[T]], func)
                 try:
@@ -354,11 +362,11 @@ class _ParametersInjection(Generic[T]):
             for param, cls in params_to_provide.items():
                 if param not in provided_params:
                     kwargs[param] = instance(cls)
-                elif param in kwargs and kwargs[param] is ...:
+                elif param in kwargs and kwargs[param] is MARKER:
                     kwargs[param] = instance(cls)
                 elif param in arg_name_tuple:
                     idx = arg_name_tuple.index(param)
-                    if args[idx] is ...:
+                    if args[idx] is MARKER:
                         args = args[:idx] + (instance(cls),) + args[idx + 1:]
             sync_func = cast(Callable[..., T], func)
             try:

--- a/test/test_autoparams.py
+++ b/test/test_autoparams.py
@@ -17,6 +17,8 @@ class TestInjectAutoparams(BaseTestInject):
         inject.configure(lambda binder: binder.bind(int, 123))
 
         assert test_func() == 123
+        assert test_func(inject.MARKER) == 123
+        assert test_func(val=inject.MARKER) == 123
         assert test_func(val=321) == 321
 
     def test_autoparams_multi(self):
@@ -33,8 +35,11 @@ class TestInjectAutoparams(BaseTestInject):
 
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
+        assert test_func(10, inject.MARKER) == (10, 2, 3)
+        assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, c=30) == (10, 20, 30)
+        assert test_func(a=inject.MARKER) == (1, 2, 3)
         assert test_func(a='a') == ('a', 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
@@ -56,8 +61,10 @@ class TestInjectAutoparams(BaseTestInject):
 
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
+        assert test_func(10, inject.MARKER) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, c=30) == (10, 20, 30)
+        assert test_func(a=inject.MARKER) == (1, 2, 3)
         assert test_func(a='a') == ('a', 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
@@ -78,9 +85,11 @@ class TestInjectAutoparams(BaseTestInject):
 
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
+        assert test_func(10, inject.MARKER) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, c=30) == (10, 20, 30)
         assert test_func(a='a') == ('a', 2, 3)
+        assert test_func(b=inject.MARKER) == (1, 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
         assert test_func(a=10, c=30) == (10, 2, 30)
@@ -102,9 +111,11 @@ class TestInjectAutoparams(BaseTestInject):
 
         assert test.func() == (test, 1, 2, 3)
         assert test.func(10) == (test, 10, 2, 3)
+        assert test.func(10, inject.MARKER) == (test, 10, 2, 3)
         assert test.func(10, 20) == (test, 10, 20, 3)
         assert test.func(10, 20, c=30) == (test, 10, 20, 30)
         assert test.func(a='a') == (test, 'a', 2, 3)
+        assert test.func(b=inject.MARKER) == (test, 1, 2, 3)
         assert test.func(b='b') == (test, 1, 'b', 3)
         assert test.func(c='c') == (test, 1, 2, 'c')
         assert test.func(a=10, c=30) == (test, 10, 2, 30)
@@ -127,9 +138,11 @@ class TestInjectAutoparams(BaseTestInject):
 
         assert Test.func() == (Test, 1, 2, 3)
         assert Test.func(10) == (Test, 10, 2, 3)
+        assert Test.func(10, inject.MARKER) == (Test, 10, 2, 3)
         assert Test.func(10, 20) == (Test, 10, 20, 3)
         assert Test.func(10, 20, c=30) == (Test, 10, 20, 30)
         assert Test.func(a='a') == (Test, 'a', 2, 3)
+        assert Test.func(b=inject.MARKER) == (Test, 1, 2, 3)
         assert Test.func(b='b') == (Test, 1, 'b', 3)
         assert Test.func(c='c') == (Test, 1, 2, 'c')
         assert Test.func(a=10, c=30) == (Test, 10, 2, 30)
@@ -153,9 +166,11 @@ class TestInjectAutoparams(BaseTestInject):
 
         assert test.func() == (Test, 1, 2, 3)
         assert test.func(10) == (Test, 10, 2, 3)
+        assert test.func(10, inject.MARKER) == (Test, 10, 2, 3)
         assert test.func(10, 20) == (Test, 10, 20, 3)
         assert test.func(10, 20, c=30) == (Test, 10, 20, 30)
         assert test.func(a='a') == (Test, 'a', 2, 3)
+        assert test.func(b=inject.MARKER) == (Test, 1, 2, 3)
         assert test.func(b='b') == (Test, 1, 'b', 3)
         assert test.func(c='c') == (Test, 1, 2, 'c')
         assert test.func(a=10, c=30) == (Test, 10, 2, 30)

--- a/test/test_params.py
+++ b/test/test_params.py
@@ -12,7 +12,9 @@ class TestInjectParams(BaseTestInject):
         inject.configure(lambda binder: binder.bind(int, 123))
 
         assert test_func() == 123
+        assert test_func(inject.MARKER) == 123
         assert test_func(321) == 321
+        assert test_func(val=inject.MARKER) == 123
         assert test_func(val=42) == 42
 
     def test_params_multi(self):
@@ -29,8 +31,10 @@ class TestInjectParams(BaseTestInject):
 
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
+        assert test_func(10, inject.MARKER) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, 30) == (10, 20, 30)
+        assert test_func(a=inject.MARKER) == (1, 2, 3)
         assert test_func(a='a') == ('a', 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
@@ -52,12 +56,14 @@ class TestInjectParams(BaseTestInject):
 
         assert test_func() == (1, 2, 3)
         assert test_func(10) == (10, 2, 3)
+        assert test_func(10, inject.MARKER) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, 30) == (10, 20, 30)
         assert test_func(a='a') == ('a', 2, 3)
         assert test_func(b='b') == (1, 'b', 3)
         assert test_func(c='c') == (1, 2, 'c')
         assert test_func(a=10, c=30) == (10, 2, 30)
+        assert test_func(a=10, b=inject.MARKER, c=30) == (10, 2, 30)
         assert test_func(c=30, b=20, a=10) == (10, 20, 30)
         assert test_func(10, b=20) == (10, 20, 3)
 
@@ -78,10 +84,12 @@ class TestInjectParams(BaseTestInject):
         assert test.func(10) == (test, 10, 2, 3)
         assert test.func(10, 20) == (test, 10, 20, 3)
         assert test.func(10, 20, 30) == (test, 10, 20, 30)
+        assert test.func(10, inject.MARKER, inject.MARKER) == (test, 10, 2, 3)
         assert test.func(a='a') == (test, 'a', 2, 3)
         assert test.func(b='b') == (test, 1, 'b', 3)
         assert test.func(c='c') == (test, 1, 2, 'c')
         assert test.func(a=10, c=30) == (test, 10, 2, 30)
+        assert test.func(a=10, b=inject.MARKER, c=30) == (test, 10, 2, 30)
         assert test.func(c=30, b=20, a=10) == (test, 10, 20, 30)
         assert test.func(10, b=20) == (test, 10, 20, 3)
 
@@ -103,10 +111,12 @@ class TestInjectParams(BaseTestInject):
         assert Test.func(10) == (Test, 10, 2, 3)
         assert Test.func(10, 20) == (Test, 10, 20, 3)
         assert Test.func(10, 20, 30) == (Test, 10, 20, 30)
+        assert Test.func(10, inject.MARKER, inject.MARKER) == (Test, 10, 2, 3)
         assert Test.func(a='a') == (Test, 'a', 2, 3)
         assert Test.func(b='b') == (Test, 1, 'b', 3)
         assert Test.func(c='c') == (Test, 1, 2, 'c')
         assert Test.func(a=10, c=30) == (Test, 10, 2, 30)
+        assert Test.func(a=10, b=inject.MARKER, c=30) == (Test, 10, 2, 30)
         assert Test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert Test.func(10, b=20) == (Test, 10, 20, 3)
 
@@ -129,10 +139,12 @@ class TestInjectParams(BaseTestInject):
         assert test.func(10) == (Test, 10, 2, 3)
         assert test.func(10, 20) == (Test, 10, 20, 3)
         assert test.func(10, 20, 30) == (Test, 10, 20, 30)
+        assert test.func(10, inject.MARKER, inject.MARKER) == (Test, 10, 2, 3)
         assert test.func(a='a') == (Test, 'a', 2, 3)
         assert test.func(b='b') == (Test, 1, 'b', 3)
         assert test.func(c='c') == (Test, 1, 2, 'c')
         assert test.func(a=10, c=30) == (Test, 10, 2, 30)
+        assert test.func(a=10, b=inject.MARKER, c=30) == (Test, 10, 2, 30)
         assert test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert test.func(10, b=20) == (Test, 10, 20, 3)
 
@@ -145,5 +157,7 @@ class TestInjectParams(BaseTestInject):
 
         assert inspect.iscoroutinefunction(test_func)
         assert self.run_async(test_func()) == 123
+        assert self.run_async(test_func(inject.MARKER)) == 123
         assert self.run_async(test_func(321)) == 321
+        assert self.run_async(test_func(val=inject.MARKER)) == 123
         assert self.run_async(test_func(val=42)) == 42


### PR DESCRIPTION
Thank you for bringing this awesome project to life!

I was working on a project and came up to this kind of code where `a_setting` and `b_setting` control the parameters of `some_injectable_function`:

```
import inject

@inject.params(a=10, b=20, c=30)
def some_injectable_function(a, b, c):
    ...

def some_function(a_setting=True, b_setting=False):
    if a_setting and b_setting:
        result = some_injectable_function(a=1, b=1, c=1)
    elif a_setting:
        result = some_injectable_function(a=1, c=1)
    elif b_setting:
        result = some_injectable_function(b=1)
    else:
        result = some_injectable_function()
```
...but I thought this will get more complex and uneasy to read if there's more conditions and parameters. I think this problem comes from not having ways to explicitly set a parameter to be injected.

With this PR, you would be able to write it like
```
import inject

@inject.params(a=10, b=20, c=30)
def some_injectable_function(a, b, c):
    ...

def some_function(a_setting=True, b_setting=False):
    result = some_injectable_function(
        a=1 if a_setting else inject.MARKER,
        b=1 if b_setting else inject.MARKER,
        c=1 if a_setting else inject.MARKER,
    )
```
or
```
import inject

@inject.params(a=10, b=20, c=30)
def some_injectable_function(a, b, c):
    ...

def some_function(a_setting=True, b_setting=False):
    a = b = c = inject.MARKER
    if a_setting:
        a = c = 1
    if b_setting:
        b = 1
    result = some_injectable_function(a, b, c)
```

Comments well appreciated! Please tell me if there's any flaw in my code.