### PR TITLE
Optionally allow overriding of dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 python-inject changes
 =====================
 
+### 5.0.1 (2023-10-16)
+- Optionally allow overriding dependencies.
+
 ### 5.0.0 (2023-06-10)
 - Support for PEP0604 for Python>=3.10.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ class User(object):
 
 # Create an optional configuration.
 def my_config(binder):
-    binder.install(my_config2)  # Add bindings from another config.
     binder.bind(Cache, RedisCache('localhost:1234'))
 
 # Configure a shared injector.
@@ -133,11 +132,31 @@ and optionally `inject.clear()` to clean up on tear down:
 class MyTest(unittest.TestCase):
     def setUp(self):
         inject.clear_and_configure(lambda binder: binder
-            .bind(Cache, Mock()) \
+            .bind(Cache, MockCache()) \
             .bind(Validator, TestValidator()))
     
     def tearDown(self):
         inject.clear()
+```
+
+## Composable configurations
+You can reuse configurations and override already registered dependencies to fit the needs in different environments or specific tests.
+```python
+    def base_config(binder):
+        # ... more dependencies registered here
+        binder.bind(Validator, RealValidator())
+        binder.bind(Cache, RedisCache('localhost:1234'))
+
+    def tests_config(binder):
+        # reuse existing configuration
+        binder.install(base_config)
+
+        # override only certain dependencies
+        binder.bind(Validator, TestValidator())
+        binder.bind(Cache, MockCache())
+    
+    inject.clear_and_configure(tests_config, allow_override=True)
+        
 ```
 
 ## Thread-safety

--- a/test/test_binder.py
+++ b/test/test_binder.py
@@ -13,15 +13,19 @@ class TestBinder(TestCase):
     def test_bind__class_required(self):
         binder = Binder()
 
-        self.assertRaisesRegex(InjectorException, 'Binding key cannot be None',
-                                binder.bind, None, None)
+        self.assertRaisesRegex(InjectorException, 'Binding key cannot be None', binder.bind, None, None)
 
     def test_bind__duplicate_binding(self):
         binder = Binder()
         binder.bind(int, 123)
 
-        self.assertRaisesRegex(InjectorException, "Duplicate binding",
-                                binder.bind, int, 456)
+        self.assertRaisesRegex(InjectorException, "Duplicate binding", binder.bind, int, 456)
+
+    def test_bind__allow_override(self):
+        binder = Binder(allow_override=True)
+        binder.bind(int, 123)
+        binder.bind(int, 456)
+        assert int in binder._bindings
 
     def test_bind_provider(self):
         provider = lambda: 123
@@ -32,8 +36,7 @@ class TestBinder(TestCase):
 
     def test_bind_provider__provider_required(self):
         binder = Binder()
-        self.assertRaisesRegex(InjectorException, "Provider cannot be None",
-                                binder.bind_to_provider, int, None)
+        self.assertRaisesRegex(InjectorException, "Provider cannot be None", binder.bind_to_provider, int, None)
 
     def test_bind_constructor(self):
         constructor = lambda: 123
@@ -44,5 +47,4 @@ class TestBinder(TestCase):
 
     def test_bind_constructor__constructor_required(self):
         binder = Binder()
-        self.assertRaisesRegex(InjectorException, "Constructor cannot be None",
-                                binder.bind_to_constructor, int, None)
+        self.assertRaisesRegex(InjectorException, "Constructor cannot be None", binder.bind_to_constructor, int, None)

--- a/test/test_inject_configuration.py
+++ b/test/test_inject_configuration.py
@@ -4,7 +4,6 @@ from test import BaseTestInject
 
 
 class TestInjectConfiguration(BaseTestInject):
-
     def test_configure__should_create_injector(self):
         injector0 = inject.configure()
         injector1 = inject.get_injector()
@@ -19,8 +18,7 @@ class TestInjectConfiguration(BaseTestInject):
     def test_configure__already_configured(self):
         inject.configure()
 
-        self.assertRaisesRegex(InjectorException, 'Injector is already configured',
-                                inject.configure)
+        self.assertRaisesRegex(InjectorException, 'Injector is already configured', inject.configure)
 
     def test_configure_once__should_create_injector(self):
         injector = inject.configure_once()
@@ -48,11 +46,19 @@ class TestInjectConfiguration(BaseTestInject):
         assert injector1 is not injector0
 
     def test_get_injector_or_die(self):
-        self.assertRaisesRegex(InjectorException, 'No injector is configured',
-                                inject.get_injector_or_die)
+        self.assertRaisesRegex(InjectorException, 'No injector is configured', inject.get_injector_or_die)
 
     def test_configure__runtime_binding_disabled(self):
         injector = inject.configure(bind_in_runtime=False)
-        self.assertRaisesRegex(InjectorException,
-                                "No binding was found for key=<.* 'int'>",
-                                injector.get_instance, int)
+        self.assertRaisesRegex(InjectorException, "No binding was found for key=<.* 'int'>", injector.get_instance, int)
+
+    def test_configure__install_allow_override(self):
+        def base_config(binder):
+            binder.bind(int, 123)
+
+        def config(binder):
+            binder.install(base_config)
+            binder.bind(int, 456)
+
+        injector = inject.configure(config, allow_override=True)
+        assert injector.get_instance(int) == 456


### PR DESCRIPTION
Relates to [this](https://github.com/ivankorobkov/python-inject/issues/65 discussion.

**Preface**
When configuring injector for different environments often times you need to use a the same core configuration and swap only a few dependencies. This also happens for specific tests when you need to mock something or tweak some service's configuration.
The current implementation only allows for installing an exising config with `binder.install` and then build up upon it without overriding dependencies.
This unflexibility forces developers to always create configurations from scratch for every environment or for specific tests which leads to code duplications and when introducing new dependencies in your core configuration, you have to specify them in every other config as well.

**Solution**
With the following changes configurations are composable with the ability to allow overriding of dependencies for example:

#  base config in core module
def core_config(binder):
  binder.bind(BaseUserService, UserService)
  binder.bind(BaseCase, Cache)
  binder.bind(BaseJobRunner, JobRunner)
  binder.bind(BaseLogger, ConsoleLogger)
  
# base test config
def test_config(binder):
   # reuse core config
   binder.install(core_config)

   # override some dependencies
   binder.bind(BaseCase, MockCache)
   binder.bind(BaseJobRunner, MockJobRunner)

# configuration where you need to mock user service 
def specific_test_config(binder):
    # reuse base test config
    binder.install(test_config)
     # override some dependencies
    binder.bind(BaseUserService, MockUserService)

# another process that runs the same code base with another logger
def job_runner_config(binder):
   # reuse core config
    binder.install(core_config)
    
    # override some dependencies
    binder.bind(BaseLogger, JobRunLogger)
    
    
 