### PR TITLE
Allow provider to be a context manager (sync/async)

### DIFF
--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -342,9 +342,9 @@ class _ParametersInjection(Generic[T]):
                 for param, cls in params_to_provide.items():
                     if param not in provided_params:
                         inst = instance(cls)
-                        if isinstance(inst, contextlib.AbstractContextManager):
+                        if isinstance(inst, contextlib._GeneratorContextManager):
                             ctx_managers[param] = inst
-                        elif isinstance(inst, contextlib.AbstractAsyncContextManager):
+                        elif isinstance(inst, contextlib._AsyncGeneratorContextManager):
                             async_ctx_managers[param] = inst
                         else:
                             kwargs[param] = inst
@@ -372,7 +372,7 @@ class _ParametersInjection(Generic[T]):
             for param, cls in params_to_provide.items():
                 if param not in provided_params:
                     inst = instance(cls)
-                    if isinstance(inst, contextlib.AbstractContextManager):
+                    if isinstance(inst, contextlib._GeneratorContextManager):
                         ctx_managers[param] = inst
                     else:
                         kwargs[param] = inst

--- a/test/test_context_manager.py
+++ b/test/test_context_manager.py
@@ -1,0 +1,107 @@
+import contextlib
+
+import inject
+from test import BaseTestInject
+
+
+class Destroyable:
+    def __init__(self):
+        self.started = True
+
+    def destroy(self):
+        self.started = False
+
+
+class MockFile(Destroyable):
+    ...
+
+
+class MockConnection(Destroyable):
+    ...
+
+
+class MockFoo(Destroyable):
+    ...
+
+
+@contextlib.contextmanager
+def get_file_sync():
+    obj = MockFile()
+    yield obj
+    obj.destroy()
+
+
+@contextlib.contextmanager
+def get_conn_sync():
+    obj = MockConnection()
+    yield obj
+    obj.destroy()
+
+
+@contextlib.contextmanager
+def get_foo_sync():
+    obj = MockFoo()
+    yield obj
+    obj.destroy()
+
+
+@contextlib.asynccontextmanager
+async def get_file_async():
+    obj = MockFile()
+    yield obj
+    obj.destroy()
+
+
+@contextlib.asynccontextmanager
+async def get_conn_async():
+    obj = MockConnection()
+    yield obj
+    obj.destroy()
+
+
+class TestContextManagerFunctional(BaseTestInject):
+
+    def test_provider_as_context_manager_sync(self):
+        def config(binder):
+            binder.bind_to_provider(MockFile, get_file_sync)
+            binder.bind(int, 100)
+            binder.bind_to_provider(str, lambda: "Hello")
+            binder.bind_to_provider(MockConnection, get_conn_sync)
+
+        inject.configure(config)
+
+        @inject.autoparams()
+        def mock_func(conn: MockConnection, name: str, f: MockFile, number: int):
+            assert f.started
+            assert conn.started
+            assert name == "Hello"
+            assert number == 100
+            return f, conn
+
+        f_, conn_ = mock_func()
+        assert not f_.started
+        assert not conn_.started
+
+    def test_provider_as_context_manager_async(self):
+        def config(binder):
+            binder.bind_to_provider(MockFile, get_file_async)
+            binder.bind(int, 100)
+            binder.bind_to_provider(str, lambda: "Hello")
+            binder.bind_to_provider(MockConnection, get_conn_async)
+            binder.bind_to_provider(MockFoo, get_foo_sync)
+
+        inject.configure(config)
+
+        @inject.autoparams()
+        async def mock_func(conn: MockConnection, name: str, f: MockFile, number: int, foo: MockFoo):
+            assert f.started
+            assert conn.started
+            assert foo.started
+            assert name == "Hello"
+            assert number == 100
+            return f, conn, foo
+
+        f_, conn_, foo_ = self.run_async(mock_func())
+        assert not f_.started
+        assert not conn_.started
+        assert not foo_.started


### PR DESCRIPTION
## Allow a provider to be used as context manager

#### Problem statement:
- A variable provided through context manager is useful in case it is a resource that needs to be cleaned up immediately after the caller has finished. Example of this is a PGBouncer session.
- Bind a class to an instance of a context manager (through `bind` or `bind_to_constructor`) or to a function decorated as a context manager leads to the context manager to be used as is, not via `with` statement

#### Proposed change:
- In `async_injection_wrapper` and `injection_wrapper`: extract the provided instances from `kwargs` if they are subclasses of `AbstractContextManager` or `AbstractAsyncContextManager`
- Stack them up in a list (or two lists in case of async - we allow async func to be a mixture of sync and async ContextManagers )
- Before executing the function, use `ExitStack` (and/or `AsyncExitStack`) to enter all contexts, the return values are updated to `kwargs` and finally sent to the function

#### Testing
- One new unittest added