### PR TITLE
Added context manager condition to attr function(Fix #94)

### DIFF
--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -73,7 +73,6 @@ all other classes are runtime bindings::
     inject.configure(my_config)
 
 """
-import asyncio
 import contextlib
 
 from inject._version import __version__


### PR DESCRIPTION
``` python
class SyncCM:
    def __init__(self, i):
        self.i = i
    def __enter__(self):
        print('enter')
        return self
    def __exit__(self, *args):
        print('exit')
        return self
    def test(self, j: int):
        return j

@contextmanager
def get_cm() -> Iterator[object]:
    with SyncCM(10) as cm:
        yield cm

class Repo:
    _cm:SyncCM = inject.attr(SyncCM)
    
    def cm_test(self):
        result = self._cm.test(20)
        return result
  

def configure(binder:inject.Binder):
    binder.bind_to_provider(SyncCM, get_cm)

inject.configure(configure)

r:Repo = inject.instance(Repo)
result = r.cm_test()
print(result)
```

Resolved the error occurring(#94) when using `@contextmanager` in the parameter function of `.bind_to_provider` function

`@contextmanager`: Resolved
`@asynccontextmanager`: Replaced with an Exception since a way to use Descriptors asynchronously could not be found.