### PR TITLE
Fix type checking error while passing a lambda to `inject.configure`

### DIFF
--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -113,7 +113,7 @@ T = TypeVar('T', bound=Injectable)
 Binding = Union[Type[Injectable], Hashable]
 Constructor = Callable[[], Injectable]
 Provider = Constructor
-BinderCallable = Callable[['Binder'], None]
+BinderCallable = Callable[['Binder'], Optional['Binder']]
 
 
 class ConstructorTypeError(TypeError):


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8954ce54-8977-4769-8006-6cbea981099f)
