### PR TITLE
Enable Overriding of Hashables with allow_override=True

### DIFF
--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -182,7 +182,7 @@ class Binder(object):
 
         if self._is_forward_str(cls):
             ref = ForwardRef(cls)
-            if ref in self._bindings:
+            if not self.allow_override and ref in self._bindings:
                 raise InjectorException('Duplicate forward binding, i.e. "int" and int, key=%s', cls)
     
     def _maybe_bind_forward(self, cls: Binding, binding: Any) -> None:


### PR DESCRIPTION
This code modification enables hashables to be overwritten when the allow_override parameter is set to True. Previously, the library would crash if a hashable was overwritten. This change allows overrides, preventing the library from crashing in such scenarios.

Thanks to @jjlangen for contributing to this change.