### PR TITLE
Handle autoparams usage without braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,3 +334,4 @@ Apache License 2.0
 * 45deg [@45deg](https://github.com/45deg)
 * Alexander Nicholas Costas [@ancostas](https://github.com/ancostas)
 * Dmitry Balabka [@dbalabka](https://github.com/dbalabka)
+* Dima Burmistrov [@pyctrl](https://github.com/pyctrl)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install inject
 that uses type annotations. This is supported only in Python >= 3.5.
 
 ```python
-@inject.autoparams()
+@inject.autoparams
 def refresh_cache(cache: RedisCache, db: DbInterface):
     pass
 ```
@@ -48,6 +48,9 @@ injecting everything:
 def sign_up(name, email, cache: RedisCache, db: DbInterface):
     pass
 ```
+
+It is also acceptable to use explicit curly braces notation (`@inject.autoparams()`)
+for non-parameterized decorations — it will be treated the same as `@inject.autoparams`.
 
 ## Step-by-step example
 ```python

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -541,7 +541,7 @@ def autoparams(*selected: str) -> Callable:
 
     For example::
 
-        @inject.autoparams()
+        @inject.autoparams
         def refresh_cache(cache: RedisCache, db: DbInterface):
             pass
 

--- a/test/test_autoparams.py
+++ b/test/test_autoparams.py
@@ -11,7 +11,10 @@ class B: pass
 class C: pass
 
 
-class TestInjectAutoparams(BaseTestInject):
+class TestInjectEmptyAutoparams(BaseTestInject):
+    def test_autoparams_non_parametrized(self):
+        pass
+
     def test_autoparams_by_class(self):
         @inject.autoparams()
         def test_func(val: int = None):
@@ -165,6 +168,21 @@ class TestInjectAutoparams(BaseTestInject):
         assert test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert test.func(10, b=20) == (Test, 10, 20, 3)
 
+    def test_autoparams_omits_return_type(self):
+        @inject.autoparams()
+        def test_func(a: str) -> int:
+            return a
+
+        def config(binder):
+            binder.bind(str, 'bazinga')
+
+        inject.configure(config)
+
+        assert test_func() == 'bazinga'
+
+
+class TestInjectSelectedAutoparams(BaseTestInject):
+
     def test_autoparams_only_selected(self):
         @inject.autoparams('a', 'c')
         def test_func(a: 'A', b: 'B', *, c: 'C'):
@@ -212,15 +230,3 @@ class TestInjectAutoparams(BaseTestInject):
 
         self.assertRaises(TypeError, test_func)
         self.assertRaises(TypeError, test_func, a=1, c=3)
-
-    def test_autoparams_omits_return_type(self):
-        @inject.autoparams()
-        def test_func(a: str) -> int:
-            return a
-
-        def config(binder):
-            binder.bind(str, 'bazinga')
-
-        inject.configure(config)
-
-        assert test_func() == 'bazinga'

--- a/test/test_autoparams.py
+++ b/test/test_autoparams.py
@@ -11,12 +11,13 @@ class B: pass
 class C: pass
 
 
-class TestInjectEmptyAutoparams(BaseTestInject):
-    def test_autoparams_non_parametrized(self):
-        pass
+class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
+    @staticmethod
+    def _get_decorator():
+        return inject.autoparams()
 
     def test_autoparams_by_class(self):
-        @inject.autoparams()
+        @self._get_decorator()
         def test_func(val: int = None):
             return val
 
@@ -26,7 +27,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         assert test_func(val=321) == 321
 
     def test_autoparams_multi(self):
-        @inject.autoparams()
+        @self._get_decorator()
         def test_func(a: A, b: B, *, c: C):
             return a, b, c
 
@@ -49,7 +50,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         assert test_func(10, b=20) == (10, 20, 3)
 
     def test_autoparams_strings(self):
-        @inject.autoparams()
+        @self._get_decorator()
         def test_func(a: 'A', b: 'B', *, c: 'C'):
             return a, b, c
 
@@ -72,7 +73,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         assert test_func(10, b=20) == (10, 20, 3)
 
     def test_autoparams_with_defaults(self):
-        @inject.autoparams()
+        @self._get_decorator()
         def test_func(a=1, b: 'B' = None, *, c: 'C' = 300):
             return a, b, c
 
@@ -95,7 +96,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
 
     def test_autoparams_on_method(self):
         class Test:
-            @inject.autoparams()
+            @self._get_decorator()
             def func(self, a=1, b: 'B' = None, *, c: 'C' = None):
                 return self, a, b, c
 
@@ -121,7 +122,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         class Test:
             # note inject must be *before* classmethod!
             @classmethod
-            @inject.autoparams()
+            @self._get_decorator()
             def func(cls, a=1, b: 'B' = None, *, c: 'C' = None):
                 return cls, a, b, c
 
@@ -146,7 +147,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         class Test:
             # note inject must be *before* classmethod!
             @classmethod
-            @inject.autoparams()
+            @self._get_decorator()
             def func(cls, a=1, b: 'B' = None, *, c: 'C' = None):
                 return cls, a, b, c
 
@@ -169,7 +170,7 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         assert test.func(10, b=20) == (Test, 10, 20, 3)
 
     def test_autoparams_omits_return_type(self):
-        @inject.autoparams()
+        @self._get_decorator()
         def test_func(a: str) -> int:
             return a
 
@@ -179,6 +180,12 @@ class TestInjectEmptyAutoparams(BaseTestInject):
         inject.configure(config)
 
         assert test_func() == 'bazinga'
+
+
+class TestInjectEmptyAutoparamsNoBraces(TestInjectEmptyAutoparamsWithBraces):
+    @staticmethod
+    def _get_decorator():
+        return inject.autoparams
 
 
 class TestInjectSelectedAutoparams(BaseTestInject):


### PR DESCRIPTION
`autoparams` decorator extension allowing autoparams decorator usage without braces (if no parameters being provided).

P.S. Idea code first — I will extend tests for this case when we will agree on the solution.