### PR TITLE
Update type hintings to follow up braceless autoparams

### DIFF
--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -536,6 +536,11 @@ def params(**args_to_classes: Binding) -> Callable:
     return _ParametersInjection(**args_to_classes)
 
 
+@overload
+def autoparams(fn: Callable[..., T]) -> Callable[..., T]:
+    ...
+
+
 def autoparams(*selected: str) -> Callable:
     """Return a decorator that will inject args into a function using type annotations, Python >= 3.5 only.
 


### PR DESCRIPTION
My previous PR didn't include correct typing updates, so this `testfile.py`

```python
import inject

@inject.autoparams
def func1(hello: str) -> None:
    print(hello)

@inject.autoparams()
def func2(hello: str) -> None:
    print(hello)

@inject.autoparams("hello")
def func3(hello: str) -> None:
    print(hello)
```

currently faces this `mypy` error:

```shell
(master) .venv/bin/mypy testfile.py 
testfile.py:3: error: Argument 1 to "autoparams" has incompatible type "Callable[[int], None]"; expected "str"
Found 1 error in 1 file (checked 1 source file)
```

In this PR I'm catching up this issue:

```shell
(typing-for-braceless-autoparams) .venv/bin/mypy testfile.py 
Success: no issues found in 1 source file
```

And here is PyCharm screenshot — there are no issues-highlighting underlines (PyCharm understanded and checked all types too).
<img width="330" height="344" alt="image" src="https://github.com/user-attachments/assets/83b119bb-4886-41cc-ba95-0c6c890cf5c1" />
