### PR TITLE
Enable ruff linting and formatting, formatted and tuned code to satis…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,22 +32,23 @@ jobs:
 #        run: |
 #          tox -e lint-git
 
-#  lint:
+  lint:
 #    name: "Linting and type checking"
-#    runs-on: ubuntu-24.04
+    name: "Linting"
+    runs-on: ubuntu-24.04
 #    strategy:
 #      fail-fast: true
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: "3.13"
-#      - name: "Install tox"
-#        run: |
-#          pip install tox
-#      - name: "Lint formatting"
-#        run: |
-#          tox -e lint-py
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: "Install tox"
+        run: |
+          pip install tox
+      - name: "Lint formatting"
+        run: |
+          tox -e lint-py
 #      - name: "Type checking"
 #        run: |
 #          tox -e lint-mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,43 +29,26 @@ homepage = "https://github.com/ivankorobkov/python-inject"
 source = "https://github.com/ivankorobkov/python-inject"
 issues = "https://github.com/ivankorobkov/python-inject/issues"
 
+
 [dependency-groups]
+dev = [
+  "ipython",
+  "ruff",
+  "mypy",
+  "yamllint",
+  { include-group = "tests" },
+]
+
 tests = [
   "pytest",
   "pytest-cov",
 ]
 
-dev = [
-  "ipython",
-  { include-group = "tests" },
-]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
-[tool.black]
-line-length = 120
-skip-string-normalization = true
-target_version = ["py39", "py310", "py311"]
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.github
-  | \.hg
-  | \.idea
-  | \.mypy_cache
-  | \.tox
-  | \.pyre_configuration
-  | \.venv
-  | _build
-  | build
-  | dist
-  | var
-)
-'''
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/inject/_version.py"
@@ -78,12 +61,14 @@ packages = ["src/inject"]
 [tool.hatch.version]
 source = "vcs"
 
+
 [tool.isort]
 case_sensitive = true
 include_trailing_comma = true
 line_length = 120
 multi_line_output = 3
 profile = "black"
+
 
 [tool.mypy]
 check_untyped_defs = true
@@ -103,6 +88,8 @@ warn_unused_ignores = true
 #strict = true  # TODO(pyctrl): improve typings and enable strict mode
 exclude = ["tests", ".venv"]
 
+
+# TODO(pyctrl): deprecate pyright — stay with mypy
 [tool.pyright]
 defineConstant = { DEBUG = true }
 exclude = []
@@ -114,69 +101,133 @@ pythonVersion = "3.11"
 reportMissingImports = true
 reportMissingTypeStubs = false
 
+
 [tool.ruff]
-ignore = [
-  "B027",   # Allow non-abstract empty methods in abstract base classes
-  "FBT003", # Allow boolean positional values in function calls, like `dict.get(... True)`
-  # Ignore checks for possible passwords
-  "S105",
-  "S106",
-  "S107",
-  # Ignore complexity
-  "C901",
-  "PLR0911",
-  "PLR0912",
-  "PLR0913",
-  "PLR0915",
-  "PLC1901", # empty string comparisons
-  "PLW2901", # `for` loop variable overwritten
-  "SIM114",  # Combine `if` branches using logical `or` operator
-]
-line-length = 120
-select = [
-  "A",
-  "B",
-  "C",
-  "DTZ",
-  "E",
-  "EM",
-  "F",
-  "FBT",
-  "I",
-  "ICN",
-  "ISC",
-  "N",
-  "PLC",
-  "PLE",
-  "PLR",
-  "PLW",
-  "Q",
-  "RUF",
-  "S",
-  "SIM",
-  "T",
-  "TID",
-  "UP",
-  "W",
-  "YTT",
-]
-target-version = ["py39", "py310", "py311"]
-unfixable = [
-  "F401", # Don't touch unused imports
+line-length = 88
+extend-exclude = [".git", ".venv", "docs"]
+
+[tool.ruff.lint]
+preview = true
+extend-select = ["ALL"]
+extend-ignore = [
+  "D10",   # missing documentation
+  "D203",  # 1 of conflicting code-styles
+  "D212",  # 1 of conflicting code-styles
+  "C408",  # allow `dict()` instead of literal
+  "TD003", # don't require issue link
+  # Completely disable
+  "FIX",
+  "CPY",
+  # formatter conflict rules
+  "W191",
+  "E111",
+  "E114",
+  "E117",
+  "EM101",
+  "EM102",
+  "ERA001", # commented code
+  "D206",
+  "D300",
+  "DOC201",
+  "DOC402",
+  "Q000",
+  "Q001",
+  "Q002",
+  "Q003",
+  "COM812",
+  "COM819",
+  "ISC001",
+  "ISC002",
+  "N818",   # Exception name should be named with an Error suffix
+  "TRY003",
+  "UP006",
+  "UP007",
+  "UP035",
+  "UP045",
+  "FA100",
 ]
 
-[tool.ruff.flake8-quotes]
-inline-quotes = "single"
+[tool.ruff.lint.extend-per-file-ignores]
+"**/tests/**/test_*.py" = [
+  "ANN",     # annotations not required in tests
+  "E731",    # Do not assign a `lambda` expression, use a `def`
+  "PLC2701", # Private name import
+  "PLR0913", # Too many arguments in function definition
+  "PLR0917", # Too many positional arguments
+  "PLR2004", # allow "magic" values in tests
+  "PLR6301", # Method could be a function, class method, or static method
+  "PT017",   # Found assertion on exception `except` block, use `pytest.raises()` instead
+  "PT027",   # Use `pytest.raises` instead of unittest-style `assertRaisesRegex`
+  "S101",    # allow asserts
+  "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
+  "SLF001",  # allow private member access
+]
+"/**/tests/__init__.py" = ["PLR6301"]
 
-[tool.ruff.flake8-tidy-imports]
-ban-relative-imports = "all"
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+"typing" = "t"
 
-[tool.ruff.isort]
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = ["dataclasses", "inject", "typing"]
+
+[tool.ruff.lint.isort]
+force-single-line = true
 known-first-party = ["inject"]
 
-[tool.ruff.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"/**/test_*.py" = ["PLR2004", "S101", "TID252"]
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+#ignore = [
+#  "B027",   # Allow non-abstract empty methods in abstract base classes
+#  "FBT003", # Allow boolean positional values in function calls, like `dict.get(... True)`
+#  # Ignore checks for possible passwords
+#  "S105",
+#  "S106",
+#  "S107",
+#  # Ignore complexity
+#  "C901",
+#  "PLR0911",
+#  "PLR0912",
+#  "PLR0913",
+#  "PLR0915",
+#  "PLC1901", # empty string comparisons
+#  "PLW2901", # `for` loop variable overwritten
+#  "SIM114",  # Combine `if` branches using logical `or` operator
+#]
+#select = [
+#  "A",
+#  "B",
+#  "C",
+#  "DTZ",
+#  "E",
+#  "EM",
+#  "F",
+#  "FBT",
+#  "I",
+#  "ICN",
+#  "ISC",
+#  "N",
+#  "PLC",
+#  "PLE",
+#  "PLR",
+#  "PLW",
+#  "Q",
+#  "RUF",
+#  "S",
+#  "SIM",
+#  "T",
+#  "TID",
+#  "UP",
+#  "W",
+#  "YTT",
+#]
+#unfixable = [
+#  "F401", # Don't touch unused imports
+#]
 
 
 ####  Pytest & Coverage  ####
@@ -219,20 +270,23 @@ env_list = [
   "py311",
   "py312",
   "py313",
+  "fmt-py",
   "fmt-toml",
+  "lint-py",
   #"lint-mypy",  # TODO(pyctrl): make it green & uncomment
   "lint-toml",
   "lint-yaml",
+  #"lint-git",
   "coverage",
 ]
 
 [tool.tox.labels]
 fmt = [
-  # "fmt-py",
+  "fmt-py",
   "fmt-toml",
 ]
 lint = [
-  #"lint-py",
+  "lint-py",
   #"lint-mypy",  # TODO(pyctrl): make it green & uncomment
   "lint-toml",
   "lint-yaml",
@@ -247,6 +301,28 @@ dependency_groups = ["tests"]
 commands = [["pytest", { replace = "posargs", extend = true }]]
 
 # tox envs
+[tool.tox.env.lint-py]
+description = "Lint python files"
+deps = ["ruff"]
+skip_install = true
+commands = [
+  [
+    "ruff",
+    "format",
+    "--diff",
+    { replace = "posargs", default = [
+      "{tox_root}",
+    ], extend = true },
+  ],
+  [
+    "ruff",
+    "check",
+    { replace = "posargs", default = [
+      "{tox_root}",
+    ], extend = true },
+  ],
+]
+
 [tool.tox.env.lint-mypy]
 description = "Type checking"
 deps = ["mypy"]
@@ -272,6 +348,25 @@ commands = [
     { replace = "posargs", default = [
       "{tox_root}",
     ], extend = true },
+  ],
+]
+
+[tool.tox.env.fmt-py]
+description = "Format python files"
+deps = ["ruff"]
+skip_install = true
+commands = [
+  [
+    "ruff",
+    "format",
+    { replace = "posargs", default = ["{tox_root}"], extend = true },
+  ],
+  [
+    "ruff",
+    "check",
+    "--fix",
+    "--show-fixes",
+    { replace = "posargs", default = ["{tox_root}"], extend = true },
   ],
 ]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,14 @@
-from unittest import TestCase
 import asyncio
+import typing as t
+from unittest import TestCase
+
 import inject
 
 
 class BaseTestInject(TestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         inject.clear()
-    
-    def run_async(self, awaitable):
+
+    def run_async(self, awaitable: t.Awaitable):  # noqa: ANN201
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(awaitable)

--- a/tests/test_attr.py
+++ b/tests/test_attr.py
@@ -1,13 +1,14 @@
-from dataclasses import dataclass
+import dataclasses
+
 import inject
 from tests import BaseTestInject
 
 
 class TestInjectAttr(BaseTestInject):
     def test_attr(self):
-        @dataclass
+        @dataclasses.dataclass
         class MyDataClass:
-            field = inject.attr(int)
+            field = inject.attr(int)  # noqa: RUF045
 
         class MyClass:
             field = inject.attr(int)
@@ -28,7 +29,7 @@ class TestInjectAttr(BaseTestInject):
         assert my_dc.field == 123
 
     def test_invalid_attachment_to_dataclass(self):
-        @dataclass
+        @dataclasses.dataclass
         class MyDataClass:
             # dataclasses treat this definition as regular descriptor
             field: int = inject.attr(int)
@@ -39,11 +40,11 @@ class TestInjectAttr(BaseTestInject):
         descriptor = inject.attr(int)
         auto_descriptor = inject.attr()
 
-        @dataclass
+        @dataclasses.dataclass
         class MyDataClass:
-            field = descriptor
+            field = descriptor  # noqa: RUF045
 
-        class MyClass(object):
+        class MyClass:
             field = descriptor
             field2: int = descriptor
             auto_typed_field: int = auto_descriptor

--- a/tests/test_autoparams.py
+++ b/tests/test_autoparams.py
@@ -1,14 +1,20 @@
 import sys
-from typing import Optional
-
-from tests import BaseTestInject
+import typing as t
 
 import inject
+from tests import BaseTestInject
 
 
-class A: pass
-class B: pass
-class C: pass
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class C:
+    pass
 
 
 class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
@@ -18,7 +24,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
 
     def test_autoparams_by_class(self):
         @self._get_decorator()
-        def test_func(val: int = None):
+        def test_func(val: t.Optional[int] = None):
             return val
 
         inject.configure(lambda binder: binder.bind(int, 123))
@@ -42,16 +48,16 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, c=30) == (10, 20, 30)
-        assert test_func(a='a') == ('a', 2, 3)
-        assert test_func(b='b') == (1, 'b', 3)
-        assert test_func(c='c') == (1, 2, 'c')
+        assert test_func(a="a") == ("a", 2, 3)
+        assert test_func(b="b") == (1, "b", 3)
+        assert test_func(c="c") == (1, 2, "c")
         assert test_func(a=10, c=30) == (10, 2, 30)
         assert test_func(c=30, b=20, a=10) == (10, 20, 30)
         assert test_func(10, b=20) == (10, 20, 3)
 
     def test_autoparams_strings(self):
         @self._get_decorator()
-        def test_func(a: 'A', b: 'B', *, c: 'C'):
+        def test_func(a: A, b: B, *, c: C):
             return a, b, c
 
         def config(binder):
@@ -65,16 +71,16 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, c=30) == (10, 20, 30)
-        assert test_func(a='a') == ('a', 2, 3)
-        assert test_func(b='b') == (1, 'b', 3)
-        assert test_func(c='c') == (1, 2, 'c')
+        assert test_func(a="a") == ("a", 2, 3)
+        assert test_func(b="b") == (1, "b", 3)
+        assert test_func(c="c") == (1, 2, "c")
         assert test_func(a=10, c=30) == (10, 2, 30)
         assert test_func(c=30, b=20, a=10) == (10, 20, 30)
         assert test_func(10, b=20) == (10, 20, 3)
 
     def test_autoparams_with_defaults(self):
         @self._get_decorator()
-        def test_func(a=1, b: 'B' = None, *, c: 'C' = 300):
+        def test_func(a=1, b: B = None, *, c: C = 300):
             return a, b, c
 
         def config(binder):
@@ -87,9 +93,9 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, c=30) == (10, 20, 30)
-        assert test_func(a='a') == ('a', 2, 3)
-        assert test_func(b='b') == (1, 'b', 3)
-        assert test_func(c='c') == (1, 2, 'c')
+        assert test_func(a="a") == ("a", 2, 3)
+        assert test_func(b="b") == (1, "b", 3)
+        assert test_func(c="c") == (1, 2, "c")
         assert test_func(a=10, c=30) == (10, 2, 30)
         assert test_func(c=30, b=20, a=10) == (10, 20, 30)
         assert test_func(10, b=20) == (10, 20, 3)
@@ -97,7 +103,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
     def test_autoparams_on_method(self):
         class Test:
             @self._get_decorator()
-            def func(self, a=1, b: 'B' = None, *, c: 'C' = None):
+            def func(self, a=1, b: B = None, *, c: t.Optional[C] = None):
                 return self, a, b, c
 
         def config(binder):
@@ -111,9 +117,9 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
         assert test.func(10) == (test, 10, 2, 3)
         assert test.func(10, 20) == (test, 10, 20, 3)
         assert test.func(10, 20, c=30) == (test, 10, 20, 30)
-        assert test.func(a='a') == (test, 'a', 2, 3)
-        assert test.func(b='b') == (test, 1, 'b', 3)
-        assert test.func(c='c') == (test, 1, 2, 'c')
+        assert test.func(a="a") == (test, "a", 2, 3)
+        assert test.func(b="b") == (test, 1, "b", 3)
+        assert test.func(c="c") == (test, 1, 2, "c")
         assert test.func(a=10, c=30) == (test, 10, 2, 30)
         assert test.func(c=30, b=20, a=10) == (test, 10, 20, 30)
         assert test.func(10, b=20) == (test, 10, 20, 3)
@@ -123,7 +129,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
             # note inject must be *before* classmethod!
             @classmethod
             @self._get_decorator()
-            def func(cls, a=1, b: 'B' = None, *, c: 'C' = None):
+            def func(cls, a=1, b: B = None, *, c: t.Optional[C] = None):
                 return cls, a, b, c
 
         def config(binder):
@@ -136,9 +142,9 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
         assert Test.func(10) == (Test, 10, 2, 3)
         assert Test.func(10, 20) == (Test, 10, 20, 3)
         assert Test.func(10, 20, c=30) == (Test, 10, 20, 30)
-        assert Test.func(a='a') == (Test, 'a', 2, 3)
-        assert Test.func(b='b') == (Test, 1, 'b', 3)
-        assert Test.func(c='c') == (Test, 1, 2, 'c')
+        assert Test.func(a="a") == (Test, "a", 2, 3)
+        assert Test.func(b="b") == (Test, 1, "b", 3)
+        assert Test.func(c="c") == (Test, 1, 2, "c")
         assert Test.func(a=10, c=30) == (Test, 10, 2, 30)
         assert Test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert Test.func(10, b=20) == (Test, 10, 20, 3)
@@ -148,7 +154,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
             # note inject must be *before* classmethod!
             @classmethod
             @self._get_decorator()
-            def func(cls, a=1, b: 'B' = None, *, c: 'C' = None):
+            def func(cls, a=1, b: B = None, *, c: t.Optional[C] = None):
                 return cls, a, b, c
 
         def config(binder):
@@ -162,9 +168,9 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
         assert test.func(10) == (Test, 10, 2, 3)
         assert test.func(10, 20) == (Test, 10, 20, 3)
         assert test.func(10, 20, c=30) == (Test, 10, 20, 30)
-        assert test.func(a='a') == (Test, 'a', 2, 3)
-        assert test.func(b='b') == (Test, 1, 'b', 3)
-        assert test.func(c='c') == (Test, 1, 2, 'c')
+        assert test.func(a="a") == (Test, "a", 2, 3)
+        assert test.func(b="b") == (Test, 1, "b", 3)
+        assert test.func(c="c") == (Test, 1, 2, "c")
         assert test.func(a=10, c=30) == (Test, 10, 2, 30)
         assert test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert test.func(10, b=20) == (Test, 10, 20, 3)
@@ -175,11 +181,11 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
             return a
 
         def config(binder):
-            binder.bind(str, 'bazinga')
+            binder.bind(str, "bazinga")
 
         inject.configure(config)
 
-        assert test_func() == 'bazinga'
+        assert test_func() == "bazinga"
 
 
 class TestInjectEmptyAutoparamsNoBraces(TestInjectEmptyAutoparamsWithBraces):
@@ -189,10 +195,9 @@ class TestInjectEmptyAutoparamsNoBraces(TestInjectEmptyAutoparamsWithBraces):
 
 
 class TestInjectSelectedAutoparams(BaseTestInject):
-
     def test_autoparams_only_selected(self):
-        @inject.autoparams('a', 'c')
-        def test_func(a: 'A', b: 'B', *, c: 'C'):
+        @inject.autoparams("a", "c")
+        def test_func(a: A, b: B, *, c: C):
             return a, b, c
 
         def config(binder):
@@ -206,8 +211,8 @@ class TestInjectSelectedAutoparams(BaseTestInject):
         self.assertRaises(TypeError, test_func, a=1, c=3)
 
     def test_autoparams_only_selected_with_optional(self):
-        @inject.autoparams('a', 'c')
-        def test_func(a: 'A', b: 'B', *, c: Optional[C] = None):
+        @inject.autoparams("a", "c")
+        def test_func(a: A, b: B, *, c: t.Optional[C] = None):
             return a, b, c
 
         def config(binder):
@@ -224,8 +229,8 @@ class TestInjectSelectedAutoparams(BaseTestInject):
         if not sys.version_info[:3] >= (3, 10, 0):
             return
 
-        @inject.autoparams('a', 'c')
-        def test_func(a: 'A', b: 'B', *, c: C | None = None):
+        @inject.autoparams("a", "c")
+        def test_func(a: A, b: B, *, c: t.Optional[C] = None):
             return a, b, c
 
         def config(binder):

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -1,50 +1,74 @@
 from unittest import TestCase
 
-from inject import Binder, InjectorException
+import inject
 
 
 class TestBinder(TestCase):
     def test_bind(self):
-        binder = Binder()
+        binder = inject.Binder()
         binder.bind(int, 123)
 
         assert int in binder._bindings
 
     def test_bind__class_required(self):
-        binder = Binder()
+        binder = inject.Binder()
 
-        self.assertRaisesRegex(InjectorException, 'Binding key cannot be None', binder.bind, None, None)
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "Binding key cannot be None",
+            binder.bind,
+            None,
+            None,
+        )
 
     def test_bind__duplicate_binding(self):
-        binder = Binder()
+        binder = inject.Binder()
         binder.bind(int, 123)
 
-        self.assertRaisesRegex(InjectorException, "Duplicate binding", binder.bind, int, 456)
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "Duplicate binding",
+            binder.bind,
+            int,
+            456,
+        )
 
     def test_bind__allow_override(self):
-        binder = Binder(allow_override=True)
+        binder = inject.Binder(allow_override=True)
         binder.bind(int, 123)
         binder.bind(int, 456)
         assert int in binder._bindings
 
     def test_bind_provider(self):
         provider = lambda: 123
-        binder = Binder()
+        binder = inject.Binder()
         binder.bind_to_provider(int, provider)
 
         assert binder._bindings[int] is provider
 
     def test_bind_provider__provider_required(self):
-        binder = Binder()
-        self.assertRaisesRegex(InjectorException, "Provider cannot be None", binder.bind_to_provider, int, None)
+        binder = inject.Binder()
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "Provider cannot be None",
+            binder.bind_to_provider,
+            int,
+            None,
+        )
 
     def test_bind_constructor(self):
         constructor = lambda: 123
-        binder = Binder()
+        binder = inject.Binder()
         binder.bind_to_constructor(int, constructor)
 
         assert binder._bindings[int]._constructor is constructor
 
     def test_bind_constructor__constructor_required(self):
-        binder = Binder()
-        self.assertRaisesRegex(InjectorException, "Constructor cannot be None", binder.bind_to_constructor, int, None)
+        binder = inject.Binder()
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "Constructor cannot be None",
+            binder.bind_to_constructor,
+            int,
+            None,
+        )

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -12,16 +12,13 @@ class Destroyable:
         self.started = False
 
 
-class MockFile(Destroyable):
-    ...
+class MockFile(Destroyable): ...
 
 
-class MockConnection(Destroyable):
-    ...
+class MockConnection(Destroyable): ...
 
 
-class MockFoo(Destroyable):
-    ...
+class MockFoo(Destroyable): ...
 
 
 @contextlib.contextmanager
@@ -46,21 +43,20 @@ def get_foo_sync():
 
 
 @contextlib.asynccontextmanager
-async def get_file_async():
+async def get_file_async():  # noqa: RUF029
     obj = MockFile()
     yield obj
     obj.destroy()
 
 
 @contextlib.asynccontextmanager
-async def get_conn_async():
+async def get_conn_async():  # noqa: RUF029
     obj = MockConnection()
     yield obj
     obj.destroy()
 
 
 class TestContextManagerFunctional(BaseTestInject):
-
     def test_provider_as_context_manager_sync(self):
         def config(binder):
             binder.bind_to_provider(MockFile, get_file_sync)
@@ -93,7 +89,13 @@ class TestContextManagerFunctional(BaseTestInject):
         inject.configure(config)
 
         @inject.autoparams()
-        async def mock_func(conn: MockConnection, name: str, f: MockFile, number: int, foo: MockFoo):
+        async def mock_func(  # noqa: RUF029
+            conn: MockConnection,
+            name: str,
+            f: MockFile,
+            number: int,
+            foo: MockFoo,
+        ):
             assert f.started
             assert conn.started
             assert foo.started

--- a/tests/test_inject_configuration.py
+++ b/tests/test_inject_configuration.py
@@ -1,5 +1,4 @@
 import inject
-from inject import InjectorException
 from tests import BaseTestInject
 
 
@@ -18,7 +17,11 @@ class TestInjectConfiguration(BaseTestInject):
     def test_configure__already_configured(self):
         inject.configure()
 
-        self.assertRaisesRegex(InjectorException, 'Injector is already configured', inject.configure)
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "Injector is already configured",
+            inject.configure,
+        )
 
     def test_configure_once__should_create_injector(self):
         injector = inject.configure_once()
@@ -46,11 +49,20 @@ class TestInjectConfiguration(BaseTestInject):
         assert injector1 is not injector0
 
     def test_get_injector_or_die(self):
-        self.assertRaisesRegex(InjectorException, 'No injector is configured', inject.get_injector_or_die)
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "No injector is configured",
+            inject.get_injector_or_die,
+        )
 
     def test_configure__runtime_binding_disabled(self):
         injector = inject.configure(bind_in_runtime=False)
-        self.assertRaisesRegex(InjectorException, "No binding was found for key=<.* 'int'>", injector.get_instance, int)
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "No binding was found for key=<.* 'int'>",
+            injector.get_instance,
+            int,
+        )
 
     def test_configure__install_allow_override(self):
         def base_config(binder):

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -1,34 +1,37 @@
-from random import random
+import random
 from unittest import TestCase
 
-from inject import Injector, InjectorException
+import inject
 
 
 class TestInjector(TestCase):
     def test_instance_binding__should_use_the_same_instance(self):
-        injector = Injector(lambda binder: binder.bind(int, 123))
+        injector = inject.Injector(lambda binder: binder.bind(int, 123))
         instance = injector.get_instance(int)
         assert instance == 123
 
     def test_constructor_binding__should_construct_singleton(self):
-        injector = Injector(lambda binder: binder.bind_to_constructor(int, random))
+        injector = inject.Injector(
+            lambda binder: binder.bind_to_constructor(int, random.random)
+        )
         instance0 = injector.get_instance(int)
         instance1 = injector.get_instance(int)
 
         assert instance0 == instance1
 
     def test_provider_binding__should_call_provider_for_each_injection(self):
-        injector = Injector(lambda binder: binder.bind_to_provider(int, random))
+        injector = inject.Injector(
+            lambda binder: binder.bind_to_provider(int, random.random)
+        )
         instance0 = injector.get_instance(int)
         instance1 = injector.get_instance(int)
         assert instance0 != instance1
 
-
     def test_runtime_binding__should_create_runtime_singleton(self):
-        class MyClass(object):
+        class MyClass:
             pass
 
-        injector = Injector()
+        injector = inject.Injector()
         instance0 = injector.get_instance(MyClass)
         instance1 = injector.get_instance(MyClass)
 
@@ -36,13 +39,19 @@ class TestInjector(TestCase):
         assert isinstance(instance0, MyClass)
 
     def test_runtime_binding__not_callable(self):
-        injector = Injector()
-        self.assertRaisesRegex(InjectorException,
-                               'Cannot create a runtime binding, the key is not callable, key=123',
-                               injector.get_instance, 123)
+        injector = inject.Injector()
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "Cannot create a runtime binding, the key is not callable, key=123",
+            injector.get_instance,
+            123,
+        )
 
     def test_runtime_binding__disabled(self):
-        injector = Injector(bind_in_runtime=False)
-        self.assertRaisesRegex(InjectorException,
-                               "No binding was found for key=<.* 'int'>",
-                               injector.get_instance, int)
+        injector = inject.Injector(bind_in_runtime=False)
+        self.assertRaisesRegex(
+            inject.InjectorException,
+            "No binding was found for key=<.* 'int'>",
+            injector.get_instance,
+            int,
+        )

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -1,34 +1,35 @@
+import inspect
+
 import inject
 from tests import BaseTestInject
-import inspect
-import asyncio
+
 
 class TestInjectParams(BaseTestInject):
     def test_param_by_name(self):
-        @inject.param('val')
+        @inject.param("val")
         def test_func(val=None):
             return val
 
-        inject.configure(lambda binder: binder.bind('val', 123))
+        inject.configure(lambda binder: binder.bind("val", 123))
 
         assert test_func() == 123
         assert test_func(val=321) == 321
 
     def test_param_by_class(self):
-        @inject.param('val', int)
+        @inject.param("val", int)
         def test_func(val):
             return val
 
         inject.configure(lambda binder: binder.bind(int, 123))
 
         assert test_func() == 123
-    
+
     def test_async_param(self):
-        @inject.param('val')
-        async def test_func(val):
+        @inject.param("val")
+        async def test_func(val):  # noqa: RUF029
             return val
-        
-        inject.configure(lambda binder: binder.bind('val', 123))
+
+        inject.configure(lambda binder: binder.bind("val", 123))
 
         assert inspect.iscoroutinefunction(test_func)
         assert self.run_async(test_func()) == 123

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,7 +1,8 @@
+import inspect
+
 import inject
 from tests import BaseTestInject
-import inspect
-import asyncio
+
 
 class TestInjectParams(BaseTestInject):
     def test_params(self):
@@ -16,14 +17,14 @@ class TestInjectParams(BaseTestInject):
         assert test_func(val=42) == 42
 
     def test_params_multi(self):
-        @inject.params(a='A', b='B', c='C')
+        @inject.params(a="A", b="B", c="C")
         def test_func(a, b, c):
             return a, b, c
 
         def config(binder):
-            binder.bind('A', 1)
-            binder.bind('B', 2)
-            binder.bind('C', 3)
+            binder.bind("A", 1)
+            binder.bind("B", 2)
+            binder.bind("C", 3)
 
         inject.configure(config)
 
@@ -31,22 +32,22 @@ class TestInjectParams(BaseTestInject):
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, 30) == (10, 20, 30)
-        assert test_func(a='a') == ('a', 2, 3)
-        assert test_func(b='b') == (1, 'b', 3)
-        assert test_func(c='c') == (1, 2, 'c')
+        assert test_func(a="a") == ("a", 2, 3)
+        assert test_func(b="b") == (1, "b", 3)
+        assert test_func(c="c") == (1, 2, "c")
         assert test_func(a=10, c=30) == (10, 2, 30)
         assert test_func(c=30, b=20, a=10) == (10, 20, 30)
         assert test_func(10, b=20) == (10, 20, 3)
 
     def test_params_with_defaults(self):
         # note the inject overrides default parameters
-        @inject.params(b='B', c='C')
+        @inject.params(b="B", c="C")
         def test_func(a=1, b=None, c=300):
             return a, b, c
 
         def config(binder):
-            binder.bind('B', 2)
-            binder.bind('C', 3)
+            binder.bind("B", 2)
+            binder.bind("C", 3)
 
         inject.configure(config)
 
@@ -54,22 +55,22 @@ class TestInjectParams(BaseTestInject):
         assert test_func(10) == (10, 2, 3)
         assert test_func(10, 20) == (10, 20, 3)
         assert test_func(10, 20, 30) == (10, 20, 30)
-        assert test_func(a='a') == ('a', 2, 3)
-        assert test_func(b='b') == (1, 'b', 3)
-        assert test_func(c='c') == (1, 2, 'c')
+        assert test_func(a="a") == ("a", 2, 3)
+        assert test_func(b="b") == (1, "b", 3)
+        assert test_func(c="c") == (1, 2, "c")
         assert test_func(a=10, c=30) == (10, 2, 30)
         assert test_func(c=30, b=20, a=10) == (10, 20, 30)
         assert test_func(10, b=20) == (10, 20, 3)
 
     def test_params_on_method(self):
         class Test:
-            @inject.params(b='B', c='C')
+            @inject.params(b="B", c="C")
             def func(self, a=1, b=None, c=None):
                 return self, a, b, c
 
         def config(binder):
-            binder.bind('B', 2)
-            binder.bind('C', 3)
+            binder.bind("B", 2)
+            binder.bind("C", 3)
 
         inject.configure(config)
         test = Test()
@@ -78,9 +79,9 @@ class TestInjectParams(BaseTestInject):
         assert test.func(10) == (test, 10, 2, 3)
         assert test.func(10, 20) == (test, 10, 20, 3)
         assert test.func(10, 20, 30) == (test, 10, 20, 30)
-        assert test.func(a='a') == (test, 'a', 2, 3)
-        assert test.func(b='b') == (test, 1, 'b', 3)
-        assert test.func(c='c') == (test, 1, 2, 'c')
+        assert test.func(a="a") == (test, "a", 2, 3)
+        assert test.func(b="b") == (test, 1, "b", 3)
+        assert test.func(c="c") == (test, 1, 2, "c")
         assert test.func(a=10, c=30) == (test, 10, 2, 30)
         assert test.func(c=30, b=20, a=10) == (test, 10, 20, 30)
         assert test.func(10, b=20) == (test, 10, 20, 3)
@@ -89,13 +90,13 @@ class TestInjectParams(BaseTestInject):
         class Test:
             # note inject must be *before* classmethod!
             @classmethod
-            @inject.params(b='B', c='C')
+            @inject.params(b="B", c="C")
             def func(cls, a=1, b=None, c=None):
                 return cls, a, b, c
 
         def config(binder):
-            binder.bind('B', 2)
-            binder.bind('C', 3)
+            binder.bind("B", 2)
+            binder.bind("C", 3)
 
         inject.configure(config)
 
@@ -103,9 +104,9 @@ class TestInjectParams(BaseTestInject):
         assert Test.func(10) == (Test, 10, 2, 3)
         assert Test.func(10, 20) == (Test, 10, 20, 3)
         assert Test.func(10, 20, 30) == (Test, 10, 20, 30)
-        assert Test.func(a='a') == (Test, 'a', 2, 3)
-        assert Test.func(b='b') == (Test, 1, 'b', 3)
-        assert Test.func(c='c') == (Test, 1, 2, 'c')
+        assert Test.func(a="a") == (Test, "a", 2, 3)
+        assert Test.func(b="b") == (Test, 1, "b", 3)
+        assert Test.func(c="c") == (Test, 1, 2, "c")
         assert Test.func(a=10, c=30) == (Test, 10, 2, 30)
         assert Test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert Test.func(10, b=20) == (Test, 10, 20, 3)
@@ -114,13 +115,13 @@ class TestInjectParams(BaseTestInject):
         class Test:
             # note inject must be *before* classmethod!
             @classmethod
-            @inject.params(b='B', c='C')
+            @inject.params(b="B", c="C")
             def func(cls, a=1, b=None, c=None):
                 return cls, a, b, c
 
         def config(binder):
-            binder.bind('B', 2)
-            binder.bind('C', 3)
+            binder.bind("B", 2)
+            binder.bind("C", 3)
 
         inject.configure(config)
         test = Test
@@ -129,16 +130,16 @@ class TestInjectParams(BaseTestInject):
         assert test.func(10) == (Test, 10, 2, 3)
         assert test.func(10, 20) == (Test, 10, 20, 3)
         assert test.func(10, 20, 30) == (Test, 10, 20, 30)
-        assert test.func(a='a') == (Test, 'a', 2, 3)
-        assert test.func(b='b') == (Test, 1, 'b', 3)
-        assert test.func(c='c') == (Test, 1, 2, 'c')
+        assert test.func(a="a") == (Test, "a", 2, 3)
+        assert test.func(b="b") == (Test, 1, "b", 3)
+        assert test.func(c="c") == (Test, 1, 2, "c")
         assert test.func(a=10, c=30) == (Test, 10, 2, 30)
         assert test.func(c=30, b=20, a=10) == (Test, 10, 20, 30)
         assert test.func(10, b=20) == (Test, 10, 20, 3)
 
     def test_async_params(self):
         @inject.params(val=int)
-        async def test_func(val):
+        async def test_func(val):  # noqa: RUF029
             return val
 
         inject.configure(lambda binder: binder.bind(int, 123))


### PR DESCRIPTION
Tried to avoid code changes at all, but a few moments came up.

Dropped Python 2 support:
```diff
-        if sys.version_info.major == 2:
-            arg_names = inspect.getargspec(func).args
-        else:
-            arg_names = inspect.getfullargspec(func).args
+        arg_names = inspect.getfullargspec(func).args
```
and
```diff
-            def __nonzero__(self):
-                """Python 2"""
-                raise NotImplementedError("Casting to boolean is not allowed")
```

Also simplified class in tests to be dataclass:
```diff
+        @dataclasses.dataclass
         class SomeClass:
-            def __init__(self, another_object: AnotherClass):
-                self.another_object = another_object
+            another_object: AnotherClass
```

Simplified this expression (linter asked for ternary operator or this one):
```diff
-if _HAS_PEP604_SUPPORT:
-    _HAS_PEP560_SUPPORT = True
-else:
-    _HAS_PEP560_SUPPORT = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
+_HAS_PEP560_SUPPORT = _HAS_PEP604_SUPPORT or sys.version_info[:3] >= (3, 7, 0)
```
