### PR TITLE
Fix `autoparams` type annotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
@@ -36,6 +37,7 @@ dev = [
   "ruff",
   "mypy",
   "yamllint",
+  "typing-extensions",
   { include-group = "tests" },
 ]
 

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -102,6 +102,12 @@ elif _HAS_PEP560_SUPPORT:
 else:
     from typing import _Union  # noqa: ICN003, PLC2701
 
+if t.TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+else:
+    P = object()
 
 logger = logging.getLogger("inject")
 
@@ -639,26 +645,15 @@ def params(**args_to_classes: Binding) -> t.Callable:
     return _ParametersInjection(**args_to_classes)
 
 
-# NOTE(pyctrl): only since 3.12
-# @t.overload
-# def autoparams[T](fn: t.Callable[..., T]) -> t.Callable[..., T]: ...
+@t.overload
+def autoparams(fn: t.Callable[P, T]) -> t.Callable[P, T]: ...
 
 
 @t.overload
-def autoparams(fn: t.Callable) -> t.Callable: ...
+def autoparams(*selected: str) -> t.Callable[[T], T]: ...
 
 
-# NOTE(pyctrl): only since 3.12
-# @t.overload
-# def autoparams[C: t.Callable](*selected: str) -> t.Callable[[C], C]:
-
-
-@t.overload
-def autoparams(*selected: str) -> t.Callable: ...
-
-
-@t.no_type_check
-def autoparams(*selected: str):
+def autoparams(*selected: t.Callable[P, T] | str) -> t.Callable[..., T]:
     """
     Return a decorator injecting args based on function type hints, only since 3.5.
 


### PR DESCRIPTION
Utilizes [ParamSpec](https://docs.python.org/3/library/typing.html#typing.ParamSpec), which was added in 3.10. But [`typing-extensions`](https://pypi.org/project/typing-extensions/) provides backports for all new types. It is not a new dependency, since mypy already depends on it