### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,6 @@ name: tests
 jobs:
 
   misc:
-#    name: "Linting configs and git"
     name: "Linting configs"
     runs-on: ubuntu-latest
     steps:
@@ -28,16 +27,10 @@ jobs:
       - name: "Lint YAMLs"
         run: |
           tox -e lint-yaml
-#      - name: "Lint git"
-#        run: |
-#          tox -e lint-git
 
   lint:
-#    name: "Linting and type checking"
     name: "Linting"
     runs-on: ubuntu-24.04
-#    strategy:
-#      fail-fast: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -49,7 +42,7 @@ jobs:
       - name: "Lint formatting"
         run: |
           tox -e lint-py
-#      - name: "Type checking"
+#      - name: "Type checking" TODO(trin94): revisit linter config and re-enable
 #        run: |
 #          tox -e lint-mypy
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 python-inject changes
 =====================
 
+### 5.5.0 (unreleased)
+- Drop Python 3.9 support (end of life). Minimum supported version is now 3.10.
+
 ### 5.4.1 (2026-07-27)
 - Fix static typing of inject.attr(Cls), #136
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Dependency injection the python way, the good way.
 * Transparently integrates into tests.
 * Autoparams leveraging type annotations.
 * Supports type hinting in Python 3.5+.
-* Supports Python 3.9+ (`v5.*`), 3.5-3.8 (`v4.*`) and Python 2.7–3.5 (`v3.*`).
 * Supports context managers.
 
 ## Python Support
 
 | Python  | Inject Version |
 |---------|----------------|
-| 3.9+    | 5.0+           |
+| 3.10+   | 5.5+           |
+| 3.9     | 5.0 - 5.4      |
 | 3.6-3.8 | 4.1+, < 5.0    |
 | 3.5     | 4.0            |
 | < 3.5   | 3.*            |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,55 +183,6 @@ ban-relative-imports = "all"
 quote-style = "double"
 indent-style = "space"
 
-#ignore = [
-#  "B027",   # Allow non-abstract empty methods in abstract base classes
-#  "FBT003", # Allow boolean positional values in function calls, like `dict.get(... True)`
-#  # Ignore checks for possible passwords
-#  "S105",
-#  "S106",
-#  "S107",
-#  # Ignore complexity
-#  "C901",
-#  "PLR0911",
-#  "PLR0912",
-#  "PLR0913",
-#  "PLR0915",
-#  "PLC1901", # empty string comparisons
-#  "PLW2901", # `for` loop variable overwritten
-#  "SIM114",  # Combine `if` branches using logical `or` operator
-#]
-#select = [
-#  "A",
-#  "B",
-#  "C",
-#  "DTZ",
-#  "E",
-#  "EM",
-#  "F",
-#  "FBT",
-#  "I",
-#  "ICN",
-#  "ISC",
-#  "N",
-#  "PLC",
-#  "PLE",
-#  "PLR",
-#  "PLW",
-#  "Q",
-#  "RUF",
-#  "S",
-#  "SIM",
-#  "T",
-#  "TID",
-#  "UP",
-#  "W",
-#  "YTT",
-#]
-#unfixable = [
-#  "F401", # Don't touch unused imports
-#]
-
-
 ####  Pytest & Coverage  ####
 [tool.pytest.ini_options]
 minversion = "8.4"
@@ -279,7 +230,6 @@ env_list = [
   #"lint-mypy",  # TODO(pyctrl): make it green & uncomment
   "lint-toml",
   "lint-yaml",
-  #"lint-git",
   "coverage",
 ]
 
@@ -294,7 +244,6 @@ lint = [
   #"lint-mypy",  # TODO(pyctrl): make it green & uncomment
   "lint-toml",
   "lint-yaml",
-  #"lint-git",
 ]
 
 # default env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ env_list = [
   "py311",
   "py312",
   "py313",
+  "py314",
   "fmt-py",
   "fmt-toml",
   "lint-py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -22,7 +21,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = []
 
 [project.urls]
@@ -218,7 +217,6 @@ runner = "uv-venv-lock-runner"
 skip_missing_interpreters = true
 
 env_list = [
-  "py39",
   "py310",
   "py311",
   "py312",


### PR DESCRIPTION
Hi again! 

Python 3.9 is end of life now, so I think it is a good time to drop it. Python 3.9 is not compatible with all latest versions of our dev-dependencies.

I made three small commits so it is easy to read: drop 3.9, remove some dead config, and add the missing tox env for 3.14.

One thing to check: CHANGES and the README assume 5.5.0 but it is your call if you prefer 6.0.0.


I also have a question: Would you be okay with using uv and adding a uv.lock file? You seemed open to it in #119. The main benefit is that we can pin the dev tools. Right now ruff is not pinned, and we run it with all rules plus preview. So every new ruff release can add errors and break CI for no real reason. With a lock file we could update ruff when we want.

If you like the idea, I can prepare a draft so you can see how it looks. I would also be happy to clean up the code a bit over time, and maybe try a newer type checker like pyrefly or ty later.

No problem if you do not want to.

Best
Elias