### PR TITLE
Fix mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ def bar(foo, cache=None):
 
 
 # `inject.attr` creates properties (descriptors) which request dependencies on access.
-class User(object):
+class User:
     cache = inject.attr(Cache)
             
     def __init__(self, id):
@@ -233,16 +233,16 @@ def config(binder):
 For example, only the `Config` class binding is present, other bindings are runtime:
 
 ```python
-class Config(object):
+class Config:
     pass
 
-class Cache(object):
+class Cache:
     config = inject.attr(Config)
 
-class Db(object):
+class Db:
     config = inject.attr(Config)
 
-class User(object):
+class User:
     cache = inject.attr(Cache)
     db = inject.attr(Db)
     
@@ -292,7 +292,7 @@ import inject
 import threading
 
 # Given a user class.
-class User(object):
+class User:
     pass
 
 # Create a thread-local current user storage.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ import inject
 
 inject.configure(lambda binder: \
     binder.bind('host', 'localhost') \
-    binder.bind('port', 1234))
+          .bind('port', 1234))
 ```
 
 ## Why no scopes?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,21 +77,9 @@ profile = "black"
 
 
 [tool.mypy]
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
 ignore_missing_imports = true
-no_implicit_optional = true
 python_version = "3.10"
-warn_redundant_casts = true
-warn_return_any = true
-warn_unused_configs = true
-warn_unused_ignores = true
-#strict = true  # TODO(pyctrl): improve typings and enable strict mode
+strict = true
 exclude = ["tests", ".venv"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,11 +147,6 @@ extend-ignore = [
   "ISC002",
   "N818",   # Exception name should be named with an Error suffix
   "TRY003",
-  "UP006",
-  "UP007",
-  "UP035",
-  "UP045",
-  "FA100",
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -626,14 +626,14 @@ def params(**args_to_classes: Binding) -> _InjectionDecorator:
 
 
 @t.overload
-def autoparams(fn: t.Callable[P, T]) -> t.Callable[P, T]: ...
+def autoparams(fn: t.Callable[P, T], /) -> t.Callable[P, T]: ...
 
 
 @t.overload
 def autoparams(*selected: str) -> t.Callable[[T], T]: ...
 
 
-def autoparams(*selected: t.Callable[P, T] | str) -> t.Callable[..., T]:
+def autoparams(*selected: t.Callable[..., t.Any] | str) -> t.Callable[..., t.Any]:
     """
     Return a decorator injecting args based on function type hints.
 
@@ -654,7 +654,9 @@ def autoparams(*selected: t.Callable[P, T] | str) -> t.Callable[..., T]:
     """
     only_these: set[str] = set()
 
-    def autoparams_decorator(fn: t.Callable[..., T]) -> t.Callable[..., T]:
+    def autoparams_decorator(
+        fn: t.Callable[..., T],
+    ) -> t.Callable[..., t.Awaitable[T] | T]:
         if inspect.isclass(fn):
             types = t.get_type_hints(fn.__init__)
         else:
@@ -677,7 +679,7 @@ def autoparams(*selected: t.Callable[P, T] | str) -> t.Callable[..., T]:
     if len(selected) == 1 and callable(target):
         return autoparams_decorator(target)
 
-    only_these.update(selected)
+    only_these.update(s for s in selected if isinstance(s, str))
     return autoparams_decorator
 
 

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -11,7 +11,7 @@ Usage:
     inject.configure(my_config)
 
 - Use `inject.instance`, `inject.attr` or `inject.param` to inject dependencies::
-    class User(object):
+    class User:
         cache = inject.attr(Cache)
 
         @classmethod
@@ -47,23 +47,23 @@ and `inject.clear()` to clean-up on tear down.
 Runtime bindings greatly reduce the required configuration by automatically creating singletons
 on first access. For example, below only the Config class requires binding configuration,
 all other classes are runtime bindings::
-    class Cache(object):
+    class Cache:
         config = inject.attr(Config)
 
         def __init__(self):
             self._redis = connect(self.config.redis_address)
 
-    class Db(object):
+    class Db:
         pass
 
-    class UserRepo(object):
+    class UserRepo:
         cache = inject.attr(Cache)
         db = inject.attr(Db)
 
         def load(self, user_id):
             return cache.load('user', user_id) or db.load('user', user_id)
 
-    class Config(object):
+    class Config:
         def __init__(self, redis_address):
             self.redis_address = redis_address
 

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -89,13 +89,6 @@ from inject._version import __version__ as __version__
 _RETURN = "return"
 _MISSING = object()
 
-if t.TYPE_CHECKING:
-    from typing_extensions import ParamSpec
-
-    P = ParamSpec("P")
-else:
-    P = object()
-
 logger = logging.getLogger("inject")
 
 _INJECTOR = None  # Shared injector instance.
@@ -104,6 +97,7 @@ _BINDING_LOCK = threading.RLock()  # Guards runtime bindings.
 
 Injectable = t.Union[object, t.Any]
 T = t.TypeVar("T", bound=Injectable)
+P = t.ParamSpec("P")
 Binding = t.Union[type[Injectable], t.Hashable]
 Constructor = t.Callable[
     [],

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -95,19 +95,18 @@ _INJECTOR = None  # Shared injector instance.
 _INJECTOR_LOCK = threading.RLock()  # Guards injector initialization.
 _BINDING_LOCK = threading.RLock()  # Guards runtime bindings.
 
-Injectable = t.Union[object, t.Any]
+Injectable = object | t.Any
 T = t.TypeVar("T", bound=Injectable)
 P = t.ParamSpec("P")
-Binding = t.Union[type[Injectable], t.Hashable]
+Binding = type[Injectable] | t.Hashable
 Constructor = t.Callable[
     [],
-    t.Union[
-        Injectable,
-        contextlib.AbstractContextManager[Injectable],
-        contextlib.AbstractAsyncContextManager[Injectable],
-    ],
+    Injectable
+    | contextlib.AbstractContextManager[Injectable]
+    | contextlib.AbstractAsyncContextManager[Injectable],
 ]
 Provider = Constructor
+# `t.Optional` because PEP 604 unions don't support forward references.
 BinderCallable = t.Callable[["Binder"], t.Optional["Binder"]]
 
 
@@ -208,7 +207,7 @@ class Injector:
 
     def __init__(
         self,
-        config: t.Optional[BinderCallable] = None,
+        config: BinderCallable | None = None,
         # TODO(pyctrl): force following flags to be kwargs
         bind_in_runtime: bool = True,  # noqa: FBT001, FBT002
         allow_override: bool = False,  # noqa: FBT001, FBT002
@@ -278,7 +277,7 @@ class InjectorException(Exception):
 
 
 class _ConstructorBinding(t.Generic[T]):
-    _instance: t.Optional[T]
+    _instance: T | None
 
     def __init__(self, constructor: t.Callable[[], T]) -> None:
         self._constructor = constructor
@@ -333,7 +332,7 @@ class _ConstructorBinding(t.Generic[T]):
 #        - `attr` implementation is inherited from `property`
 #        - `attr` class member is not annotated
 class _AttributeInjection(property):
-    def __init__(self, cls: t.Union[type[T], t.Hashable]) -> None:
+    def __init__(self, cls: type[T] | t.Hashable) -> None:
         self._cls = cls
         super().__init__(
             fget=lambda _: instance(self._cls),
@@ -348,13 +347,13 @@ class _AttributeInjection(property):
 class _ParameterInjection(t.Generic[T]):
     __slots__ = ("_cls", "_name")
 
-    def __init__(self, name: str, cls: t.Optional[Binding] = None) -> None:
+    def __init__(self, name: str, cls: Binding | None = None) -> None:
         self._name = name
         self._cls = cls
 
     def __call__(
-        self, func: t.Callable[..., t.Union[T, t.Awaitable[T]]]
-    ) -> t.Callable[..., t.Union[T, t.Awaitable[T]]]:
+        self, func: t.Callable[..., T | t.Awaitable[T]]
+    ) -> t.Callable[..., T | t.Awaitable[T]]:
         if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
@@ -419,8 +418,8 @@ class _ParametersInjection(t.Generic[T]):
         kwargs.update(executed_kwargs)
 
     def __call__(
-        self, func: t.Callable[..., t.Union[t.Awaitable[T], T]]
-    ) -> t.Callable[..., t.Union[t.Awaitable[T], T]]:
+        self, func: t.Callable[..., t.Awaitable[T] | T]
+    ) -> t.Callable[..., t.Awaitable[T] | T]:
         arg_names = inspect.getfullargspec(func).args
         params_to_provide = self._params
 
@@ -470,7 +469,7 @@ class _ParametersInjection(t.Generic[T]):
 
 
 def configure(
-    config: t.Optional[BinderCallable] = None,
+    config: BinderCallable | None = None,
     # TODO(pyctrl): force following flags to be kwargs
     bind_in_runtime: bool = True,  # noqa: FBT001, FBT002
     allow_override: bool = False,  # noqa: FBT001, FBT002
@@ -509,7 +508,7 @@ def configure(
 
 
 def configure_once(
-    config: t.Optional[BinderCallable] = None,
+    config: BinderCallable | None = None,
     # TODO(pyctrl): force following flags to be kwargs
     bind_in_runtime: bool = True,  # noqa: FBT001, FBT002
     allow_override: bool = False,  # noqa: FBT001, FBT002
@@ -529,7 +528,7 @@ def configure_once(
 
 
 def clear_and_configure(
-    config: t.Optional[BinderCallable] = None,
+    config: BinderCallable | None = None,
     # TODO(pyctrl): force following flags to be kwargs
     bind_in_runtime: bool = True,  # noqa: FBT001, FBT002
     allow_override: bool = False,  # noqa: FBT001, FBT002
@@ -605,7 +604,7 @@ def attr(cls=_MISSING):
 attr_dc = attr
 
 
-def param(name: str, cls: t.Optional[Binding] = None) -> t.Callable:
+def param(name: str, cls: Binding | None = None) -> t.Callable:
     """
     Return a decorator which injects an arg into a function.
 
@@ -683,7 +682,7 @@ def autoparams(*selected: t.Callable[P, T] | str) -> t.Callable[..., T]:
     return autoparams_decorator
 
 
-def get_injector() -> t.Optional[Injector]:
+def get_injector() -> Injector | None:
     """Return the current injector or None."""
     return _INJECTOR
 

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -223,12 +223,8 @@ class Injector:
         else:
             self._bindings = {}
 
-    # NOTE(pyctrl): only since 3.12
-    # @t.overload
-    # def get_instance(self, cls: type[T]) -> T: ...
-
     @t.overload
-    def get_instance(self, cls: Binding) -> T: ...
+    def get_instance(self, cls: type[T]) -> T: ...
 
     @t.overload
     def get_instance(self, cls: t.Hashable) -> Injectable: ...

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -714,7 +714,7 @@ def _unwrap_union_arg(typ: type) -> type:
     return args[0]
 
 
-def _is_union_type(typ: type) -> bool:
+def _is_union_type(typ: object) -> bool:
     """
     Test if the type is a union type.
 

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -108,10 +108,13 @@ Constructor = t.Callable[
 Provider = Constructor
 # `t.Optional` because PEP 604 unions don't support forward references.
 BinderCallable = t.Callable[["Binder"], t.Optional["Binder"]]
+_InjectionDecorator = t.Callable[[t.Callable[..., t.Any]], t.Callable[..., t.Any]]
 
 
 class ConstructorTypeError(TypeError):
-    def __init__(self, constructor: t.Callable, previous_error: TypeError) -> None:
+    def __init__(
+        self, constructor: t.Callable[..., t.Any], previous_error: TypeError
+    ) -> None:
         super().__init__(f"{constructor} raised an error: {previous_error}")
 
 
@@ -595,7 +598,7 @@ def attr(cls: type[T]) -> T: ...
 def attr(cls: t.Hashable) -> Injectable: ...
 
 
-def attr(cls=_MISSING):
+def attr(cls: type[T] | t.Hashable = _MISSING) -> Injectable:
     """Return an attribute injection (descriptor)."""
     return _AttributeInjection(cls)
 
@@ -604,7 +607,7 @@ def attr(cls=_MISSING):
 attr_dc = attr
 
 
-def param(name: str, cls: Binding | None = None) -> t.Callable:
+def param(name: str, cls: Binding | None = None) -> _InjectionDecorator:
     """
     Return a decorator which injects an arg into a function.
 
@@ -613,7 +616,7 @@ def param(name: str, cls: Binding | None = None) -> t.Callable:
     return _ParameterInjection(name, cls)
 
 
-def params(**args_to_classes: Binding) -> t.Callable:
+def params(**args_to_classes: Binding) -> _InjectionDecorator:
     """
     Return a decorator which injects args into a function.
 

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -710,7 +710,8 @@ def _unwrap_union_arg(typ: type) -> type:
     """Return the first type A in typing.Union[A, B] or typ if not Union."""
     if not _is_union_type(typ):
         return typ
-    return typ.__args__[0]
+    args: tuple[type, ...] = t.get_args(typ)
+    return args[0]
 
 
 def _is_union_type(typ: type) -> bool:

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -83,7 +83,6 @@ import logging
 import threading
 import typing as t
 from types import UnionType
-from typing import _GenericAlias  # noqa: ICN003, PLC2701
 
 from inject._version import __version__ as __version__
 
@@ -729,14 +728,8 @@ def _is_union_type(typ: type) -> bool:
         is_union_type(Union) == True
         is_union_type(Union[int, int]) == False
         is_union_type(Union[T, int]) == True
-
-    Source: https://github.com/ilevkivskyi/typing_inspect/blob/master/typing_inspect.py
     """
-    return (
-        typ is t.Union
-        or isinstance(typ, UnionType)
-        or (isinstance(typ, _GenericAlias) and typ.__origin__ is t.Union)
-    )
+    return typ is t.Union or isinstance(typ, UnionType) or t.get_origin(typ) is t.Union
 
 
 def _unwrap_cls_annotation(cls: type, attr_name: str) -> type:

--- a/src/inject/__init__.py
+++ b/src/inject/__init__.py
@@ -80,27 +80,15 @@ import contextlib
 import functools
 import inspect
 import logging
-import sys
 import threading
 import typing as t
+from types import UnionType
+from typing import _GenericAlias  # noqa: ICN003, PLC2701
 
 from inject._version import __version__ as __version__
 
-# PEP 604
-_HAS_PEP604_SUPPORT = sys.version_info[:3] >= (3, 10, 0)
-# PEP 560
-_HAS_PEP560_SUPPORT = _HAS_PEP604_SUPPORT or sys.version_info[:3] >= (3, 7, 0)
-
 _RETURN = "return"
 _MISSING = object()
-
-if _HAS_PEP604_SUPPORT:
-    from types import UnionType
-    from typing import _GenericAlias  # noqa: ICN003
-elif _HAS_PEP560_SUPPORT:
-    from typing import _GenericAlias  # noqa: ICN003, PLC2701
-else:
-    from typing import _Union  # noqa: ICN003, PLC2701
 
 if t.TYPE_CHECKING:
     from typing_extensions import ParamSpec
@@ -206,7 +194,7 @@ class Binder:
         if not self.allow_override and cls in self._bindings:
             raise InjectorException(f"Duplicate binding, key={cls}")
 
-        if self._is_forward_str(cls):
+        if isinstance(cls, str):
             ref = t.ForwardRef(cls)
             if not self.allow_override and ref in self._bindings:
                 msg = f'Duplicate forward binding, i.e. "int" and int, key={cls}'
@@ -214,18 +202,12 @@ class Binder:
 
     def _maybe_bind_forward(self, cls: Binding, binding: t.Any) -> None:  # noqa: ANN401
         """Bind a string forward reference."""
-        if not _HAS_PEP560_SUPPORT:
-            return
         if not isinstance(cls, str):
             return
 
         ref = t.ForwardRef(cls)
         self._bindings[ref] = binding
         logger.debug('Bound forward ref "%s"', cls)
-
-    @staticmethod
-    def _is_forward_str(kls: Binding) -> bool:
-        return _HAS_PEP560_SUPPORT and isinstance(kls, str)
 
 
 class Injector:
@@ -662,7 +644,7 @@ def autoparams(*selected: str) -> t.Callable[[T], T]: ...
 
 def autoparams(*selected: t.Callable[P, T] | str) -> t.Callable[..., T]:
     """
-    Return a decorator injecting args based on function type hints, only since 3.5.
+    Return a decorator injecting args based on function type hints.
 
     For example::
 
@@ -750,17 +732,11 @@ def _is_union_type(typ: type) -> bool:
 
     Source: https://github.com/ilevkivskyi/typing_inspect/blob/master/typing_inspect.py
     """
-    if _HAS_PEP604_SUPPORT:
-        return (
-            typ is t.Union
-            or isinstance(typ, UnionType)
-            or (isinstance(typ, _GenericAlias) and typ.__origin__ is t.Union)
-        )
-    if _HAS_PEP560_SUPPORT:
-        return typ is t.Union or (
-            isinstance(typ, _GenericAlias) and typ.__origin__ is t.Union
-        )
-    return type(typ) is _Union
+    return (
+        typ is t.Union
+        or isinstance(typ, UnionType)
+        or (isinstance(typ, _GenericAlias) and typ.__origin__ is t.Union)
+    )
 
 
 def _unwrap_cls_annotation(cls: type, attr_name: str) -> type:

--- a/tests/test_autoparams.py
+++ b/tests/test_autoparams.py
@@ -1,4 +1,3 @@
-import sys
 import typing as t
 
 import inject
@@ -226,11 +225,8 @@ class TestInjectSelectedAutoparams(BaseTestInject):
         self.assertRaises(TypeError, test_func, a=1, c=3)
 
     def test_autoparams_only_selected_with_optional_pep604_union(self):
-        if not sys.version_info[:3] >= (3, 10, 0):
-            return
-
         @inject.autoparams("a", "c")
-        def test_func(a: A, b: B, *, c: t.Optional[C] = None):
+        def test_func(a: A, b: B, *, c: C | None = None):
             return a, b, c
 
         def config(binder):

--- a/tests/test_autoparams.py
+++ b/tests/test_autoparams.py
@@ -23,7 +23,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
 
     def test_autoparams_by_class(self):
         @self._get_decorator()
-        def test_func(val: t.Optional[int] = None):
+        def test_func(val: int | None = None):
             return val
 
         inject.configure(lambda binder: binder.bind(int, 123))
@@ -102,7 +102,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
     def test_autoparams_on_method(self):
         class Test:
             @self._get_decorator()
-            def func(self, a=1, b: B = None, *, c: t.Optional[C] = None):
+            def func(self, a=1, b: B = None, *, c: C | None = None):
                 return self, a, b, c
 
         def config(binder):
@@ -128,7 +128,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
             # note inject must be *before* classmethod!
             @classmethod
             @self._get_decorator()
-            def func(cls, a=1, b: B = None, *, c: t.Optional[C] = None):
+            def func(cls, a=1, b: B = None, *, c: C | None = None):
                 return cls, a, b, c
 
         def config(binder):
@@ -153,7 +153,7 @@ class TestInjectEmptyAutoparamsWithBraces(BaseTestInject):
             # note inject must be *before* classmethod!
             @classmethod
             @self._get_decorator()
-            def func(cls, a=1, b: B = None, *, c: t.Optional[C] = None):
+            def func(cls, a=1, b: B = None, *, c: C | None = None):
                 return cls, a, b, c
 
         def config(binder):
@@ -211,7 +211,8 @@ class TestInjectSelectedAutoparams(BaseTestInject):
 
     def test_autoparams_only_selected_with_optional(self):
         @inject.autoparams("a", "c")
-        def test_func(a: A, b: B, *, c: t.Optional[C] = None):
+        # `t.Optional` coverage is the point
+        def test_func(a: A, b: B, *, c: t.Optional[C] = None):  # noqa: UP045
             return a, b, c
 
         def config(binder):

--- a/typing_checks/get_instance.py
+++ b/typing_checks/get_instance.py
@@ -1,0 +1,15 @@
+"""Static-typing regression guard for ``inject.Injector.get_instance``."""
+
+from typing_extensions import assert_type
+
+import inject
+
+
+class _Service:
+    pass
+
+
+injector = inject.Injector()
+
+assert_type(injector.get_instance(_Service), _Service)
+assert_type(injector.get_instance("service"), inject.Injectable)


### PR DESCRIPTION
Hi again,

This is a follow-up to #139. It makes the red `Type checking (library code)` job green. On top of that it enables mypy strict mode. Like in #136, I worked on this with AI assistance (Claude).

## Python 3.10 baseline cleanup

After dropping Python 3.9 (#137), some compatibility code is not needed anymore: the PEP 604/560 version checks, the `typing_extensions` ParamSpec fallback, and the private `typing._GenericAlias` / `typing._Union` imports (replaced with the public `t.get_origin()` / `t.get_args()`).

Type hints now use the PEP 604 union syntax (`X | None`). I also removed the matching pyupgrade ignores from the ruff config, so ruff keeps checking this.

Small find on the way: an earlier formatting commit changed the test annotation `C | None` to `t.Optional[C]`. So the PEP 604 test did not test PEP 604 anymore. I restored it. Now both spellings have their own test.

## Mypy: 16 errors to zero, then strict

Fixed in small commits so each one is easy to review:

* incomplete signatures (bare `t.Callable`, the untyped `attr()` implementation)
* `Injector.get_instance` now has the same `type[T]` overload as the   module-level `instance()`, with a new `typing_checks` guard like we added in #136
* the `autoparams` fn-overload is positional-only now. mypy was right here: the old type hints allowed `autoparams(fn=...)`, but that call crashes at runtime. This only changes the type hints: at runtime, `autoparams(fn=...)` always raised a TypeError, before and after
* union unwrapping goes through `t.get_args()` instead of `.__args__`

After that, mypy was at zero errors. So I enabled `strict = true` (this resolves the old TODO) and removed the single flags that strict already includes. Strict found one more wrong annotation in a private helper, which is also fixed.

There are no runtime behavior changes. The test matrix stays green on 3.10-3.14.

## README

One small fix: the "Keys" sample was a SyntaxError (a missing dot between the chained `bind` calls). I also ran all the other README samples. Some more are outdated (the context-managers sample and the classmethod + `inject.attr` examples). I might fix those in a separate PR as this one is big already.

## Suggestion: Make CI jobs mandatory before merging

In the recent PRs we locked the dependencies and cleaned up the code base and the CI. So new tool releases cannot break the CI anymore, a red job now means a real problem. And with this PR all jobs are green. I think this is a good moment to make the CI jobs mandatory for merging.

Thanks and all the best 😄
Elias
